### PR TITLE
Improve error types to allow wrapping

### DIFF
--- a/piv/piv_test.go
+++ b/piv/piv_test.go
@@ -169,7 +169,7 @@ func TestYubiKeyUnblockPIN(t *testing.T) {
 		if err == nil {
 			t.Fatalf("login with bad pin succeeded")
 		}
-		var e *errWrongPIN
+		var e AuthErr
 		if !errors.As(err, &e) {
 			t.Fatalf("error returned was not a wrong pin error: %v", err)
 		}


### PR DESCRIPTION
I got stymied not having an idiomatic way of seeing whether a smartcard object was not found or not, and I saw the TODO in the code to list error cases, so I thought I'd offer this improvement for comment.

- Promotes `apduError` to a public `ApduError` type
- Adds error messages from the latest PIV spec
- Uses error `Unwrap()` to return a few more accessible/idiomatic Go errors to enable some `errors.Is` and `errors.As` uses, such as `ErrNotFound`, `ErrBlocked`
- Promotes `errWrongPin` to `VerifyErr` type
- Changes all `%v` verbs to `%w` when wrapping errors (new in 1.13, which is what `go.mod` says we are)
- The above changes made `ykTransmit` unnecessary, so removed

I can now do things like:

```go
// Don't overwrite a slot
_, err = yk.Certificate(slot)
if err == nil {
  return errSlotOccupied
} else if !errors.Is(err, piv.ErrNotFound) {
  return err
}
```

Fixes #13 