### PR TITLE
piv: mark PC/SC connection as exclusive

### DIFF
--- a/piv/pcsc.go
+++ b/piv/pcsc.go
@@ -196,7 +196,7 @@ func (c *scContext) Connect(reader string) (*scHandle, error) {
 		activeProtocol C.DWORD
 	)
 	rc := C.SCardConnect(c.ctx, C.CString(reader),
-		C.SCARD_SHARE_SHARED, C.SCARD_PROTOCOL_T1,
+		C.SCARD_SHARE_EXCLUSIVE, C.SCARD_PROTOCOL_T1,
 		&handle, &activeProtocol)
 	if err := scCheck(rc); err != nil {
 		return nil, err


### PR DESCRIPTION
Since this package holds onto a transaction, ensure other calls to Open exit immediately instead of hanging.

Updates #45
Updates #47