### PR TITLE
add initial windows support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,13 +6,13 @@ on:
 
 jobs:
   build:
-    name: Build
+    name: Linux
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.13
-      uses: actions/setup-go@v1
+    - name: Set up Go 1.14
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.13
+        go-version: '^1.14.2'
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -21,4 +21,21 @@ jobs:
     - name: Install libpcsc
       run: sudo apt-get install -y libpcsclite-dev pcscd pcsc-tools
     - name: Test
-      run: "PATH=$PATH:$( go env GOPATH )/bin make test"
+      run: "make test"
+  build-windows:
+    name: Windows
+    runs-on: windows-latest
+    steps:
+    - name: Set up Go 1.14
+      uses: actions/setup-go@v2
+      with:
+        go-version: '^1.14.2'
+      id: go
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+    - name: Install golint
+      run: go get -u golang.org/x/lint/golint
+    - name: Test
+      run: "make build"
+      env:
+        CGO_ENABLED: 0

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
 .PHONY: test
-test:
+test: lint
 	go test -v ./...
+
+.PHONY: lint
+lint:
 	golint -set_exit_status ./...
+
+.PHONY: build
+build: lint
+	go build ./...

--- a/README.md
+++ b/README.md
@@ -248,6 +248,17 @@ sudo yum config-manager --set-enabled PowerTools
 sudo yum install pcsc-lite-devel
 ```
 
+On Windows:
+
+No prerequisites are needed. The default driver by Microsoft supports all functionalities
+which get tested by unittests. However if you run into problems try the official
+[YubiKey Smart Card Minidriver](https://www.yubico.com/products/services-software/download/smart-card-drivers-tools/). Yubico states on their website the driver adds [_additional
+smart functionality_](https://www.yubico.com/authentication-standards/smart-card/).
+
+Please notice the following:
+
+>Windows support is best effort due to lack of test hardware. This means the maintainers will take patches for Windows, but if you encounter a bug or the build is broken, you may be asked to fix it.
+
 ## Testing
 
 Tests automatically find connected available YubiKeys, but won't modify the

--- a/piv/pcsc.go
+++ b/piv/pcsc.go
@@ -14,25 +14,10 @@
 
 package piv
 
-// https://ludovicrousseau.blogspot.com/2010/04/pcsc-sample-in-c.html
-
-// TODO: Figure out if linux flags should use pkg-config instead
-
-// #cgo darwin LDFLAGS: -framework PCSC
-// #cgo linux CFLAGS: -I/usr/include/PCSC
-// #cgo linux LDFLAGS: -lpcsclite
-// #include <PCSC/winscard.h>
-// #include <PCSC/wintypes.h>
-import "C"
-
 import (
-	"bytes"
 	"errors"
 	"fmt"
-	"unsafe"
 )
-
-const rcSuccess = C.SCARD_S_SUCCESS
 
 type scErr struct {
 	// rc holds the return code for a given call.
@@ -136,121 +121,11 @@ func (a *apduErr) Unwrap() error {
 	return nil
 }
 
-type scContext struct {
-	ctx C.SCARDCONTEXT
-}
-
-func newSCContext() (*scContext, error) {
-	var ctx C.SCARDCONTEXT
-	rc := C.SCardEstablishContext(C.SCARD_SCOPE_SYSTEM, nil, nil, &ctx)
-	if err := scCheck(rc); err != nil {
-		return nil, err
-	}
-	return &scContext{ctx: ctx}, nil
-}
-
-func (c *scContext) Close() error {
-	return scCheck(C.SCardReleaseContext(c.ctx))
-}
-
-func (c *scContext) ListReaders() ([]string, error) {
-	var n C.DWORD
-	rc := C.SCardListReaders(c.ctx, nil, nil, &n)
-	// On Linux, the PC/SC daemon will return an error when no smart cards are
-	// available. Detect this and return nil with no smart cards instead.
-	//
-	// isRCNoReaders is defined in OS specific packages.
-	if isRCNoReaders(rc) {
-		return nil, nil
-	}
-
-	if err := scCheck(rc); err != nil {
-		return nil, err
-	}
-
-	d := make([]byte, n)
-	rc = C.SCardListReaders(c.ctx, nil, (*C.char)(unsafe.Pointer(&d[0])), &n)
-	if err := scCheck(rc); err != nil {
-		return nil, err
-	}
-
-	var readers []string
-	for _, d := range bytes.Split(d, []byte{0}) {
-		if len(d) > 0 {
-			readers = append(readers, string(d))
-		}
-	}
-	return readers, nil
-}
-
-type scHandle struct {
-	h C.SCARDHANDLE
-}
-
-func (c *scContext) Connect(reader string) (*scHandle, error) {
-	var (
-		handle         C.SCARDHANDLE
-		activeProtocol C.DWORD
-	)
-	rc := C.SCardConnect(c.ctx, C.CString(reader),
-		C.SCARD_SHARE_EXCLUSIVE, C.SCARD_PROTOCOL_T1,
-		&handle, &activeProtocol)
-	if err := scCheck(rc); err != nil {
-		return nil, err
-	}
-	return &scHandle{handle}, nil
-}
-
-func (h *scHandle) Close() error {
-	return scCheck(C.SCardDisconnect(h.h, C.SCARD_LEAVE_CARD))
-}
-
-type scTx struct {
-	h C.SCARDHANDLE
-}
-
-func (h *scHandle) Begin() (*scTx, error) {
-	if err := scCheck(C.SCardBeginTransaction(h.h)); err != nil {
-		return nil, err
-	}
-	return &scTx{h.h}, nil
-}
-
-func (t *scTx) Close() error {
-	return scCheck(C.SCardEndTransaction(t.h, C.SCARD_LEAVE_CARD))
-}
-
 type apdu struct {
 	instruction byte
 	param1      byte
 	param2      byte
 	data        []byte
-}
-
-func (t *scTx) transmit(req []byte) (more bool, b []byte, err error) {
-	var resp [C.MAX_BUFFER_SIZE_EXTENDED]byte
-	reqN := C.DWORD(len(req))
-	respN := C.DWORD(len(resp))
-	rc := C.SCardTransmit(
-		t.h,
-		C.SCARD_PCI_T1,
-		(*C.BYTE)(&req[0]), reqN, nil,
-		(*C.BYTE)(&resp[0]), &respN)
-	if err := scCheck(rc); err != nil {
-		return false, nil, fmt.Errorf("transmitting request: %w", err)
-	}
-	if respN < 2 {
-		return false, nil, fmt.Errorf("scard response too short: %d", respN)
-	}
-	sw1 := resp[respN-2]
-	sw2 := resp[respN-1]
-	if sw1 == 0x90 && sw2 == 0x00 {
-		return false, resp[:respN-2], nil
-	}
-	if sw1 == 0x61 {
-		return true, resp[:respN-2], nil
-	}
-	return false, nil, &apduErr{sw1, sw2}
 }
 
 func (t *scTx) Transmit(d apdu) ([]byte, error) {

--- a/piv/pcsc_unix.go
+++ b/piv/pcsc_unix.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build darwin linux
+
 package piv
 
 // https://ludovicrousseau.blogspot.com/2010/04/pcsc-sample-in-c.html

--- a/piv/pcsc_unix.go
+++ b/piv/pcsc_unix.go
@@ -1,0 +1,144 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package piv
+
+// https://ludovicrousseau.blogspot.com/2010/04/pcsc-sample-in-c.html
+
+// TODO: Figure out if linux flags should use pkg-config instead
+
+// #cgo darwin LDFLAGS: -framework PCSC
+// #cgo linux CFLAGS: -I/usr/include/PCSC
+// #cgo linux LDFLAGS: -lpcsclite
+// #include <PCSC/winscard.h>
+// #include <PCSC/wintypes.h>
+import "C"
+
+import (
+	"bytes"
+	"fmt"
+	"unsafe"
+)
+
+const rcSuccess = C.SCARD_S_SUCCESS
+
+type scContext struct {
+	ctx C.SCARDCONTEXT
+}
+
+func newSCContext() (*scContext, error) {
+	var ctx C.SCARDCONTEXT
+	rc := C.SCardEstablishContext(C.SCARD_SCOPE_SYSTEM, nil, nil, &ctx)
+	if err := scCheck(rc); err != nil {
+		return nil, err
+	}
+	return &scContext{ctx: ctx}, nil
+}
+
+func (c *scContext) Close() error {
+	return scCheck(C.SCardReleaseContext(c.ctx))
+}
+
+func (c *scContext) ListReaders() ([]string, error) {
+	var n C.DWORD
+	rc := C.SCardListReaders(c.ctx, nil, nil, &n)
+	// On Linux, the PC/SC daemon will return an error when no smart cards are
+	// available. Detect this and return nil with no smart cards instead.
+	//
+	// isRCNoReaders is defined in OS specific packages.
+	if isRCNoReaders(rc) {
+		return nil, nil
+	}
+
+	if err := scCheck(rc); err != nil {
+		return nil, err
+	}
+
+	d := make([]byte, n)
+	rc = C.SCardListReaders(c.ctx, nil, (*C.char)(unsafe.Pointer(&d[0])), &n)
+	if err := scCheck(rc); err != nil {
+		return nil, err
+	}
+
+	var readers []string
+	for _, d := range bytes.Split(d, []byte{0}) {
+		if len(d) > 0 {
+			readers = append(readers, string(d))
+		}
+	}
+	return readers, nil
+}
+
+type scHandle struct {
+	h C.SCARDHANDLE
+}
+
+func (c *scContext) Connect(reader string) (*scHandle, error) {
+	var (
+		handle         C.SCARDHANDLE
+		activeProtocol C.DWORD
+	)
+	rc := C.SCardConnect(c.ctx, C.CString(reader),
+		C.SCARD_SHARE_EXCLUSIVE, C.SCARD_PROTOCOL_T1,
+		&handle, &activeProtocol)
+	if err := scCheck(rc); err != nil {
+		return nil, err
+	}
+	return &scHandle{handle}, nil
+}
+
+func (h *scHandle) Close() error {
+	return scCheck(C.SCardDisconnect(h.h, C.SCARD_LEAVE_CARD))
+}
+
+type scTx struct {
+	h C.SCARDHANDLE
+}
+
+func (h *scHandle) Begin() (*scTx, error) {
+	if err := scCheck(C.SCardBeginTransaction(h.h)); err != nil {
+		return nil, err
+	}
+	return &scTx{h.h}, nil
+}
+
+func (t *scTx) Close() error {
+	return scCheck(C.SCardEndTransaction(t.h, C.SCARD_LEAVE_CARD))
+}
+
+func (t *scTx) transmit(req []byte) (more bool, b []byte, err error) {
+	var resp [C.MAX_BUFFER_SIZE_EXTENDED]byte
+	reqN := C.DWORD(len(req))
+	respN := C.DWORD(len(resp))
+	rc := C.SCardTransmit(
+		t.h,
+		C.SCARD_PCI_T1,
+		(*C.BYTE)(&req[0]), reqN, nil,
+		(*C.BYTE)(&resp[0]), &respN)
+	if err := scCheck(rc); err != nil {
+		return false, nil, fmt.Errorf("transmitting request: %w", err)
+	}
+	if respN < 2 {
+		return false, nil, fmt.Errorf("scard response too short: %d", respN)
+	}
+	sw1 := resp[respN-2]
+	sw2 := resp[respN-1]
+	if sw1 == 0x90 && sw2 == 0x00 {
+		return false, resp[:respN-2], nil
+	}
+	if sw1 == 0x61 {
+		return true, resp[:respN-2], nil
+	}
+	return false, nil, &apduErr{sw1, sw2}
+}

--- a/piv/pcsc_windows.go
+++ b/piv/pcsc_windows.go
@@ -1,0 +1,199 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package piv
+
+import (
+	"fmt"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	winscard                  = syscall.NewLazyDLL("Winscard.dll")
+	procSCardEstablishContext = winscard.NewProc("SCardEstablishContext")
+	procSCardListReadersW     = winscard.NewProc("SCardListReadersW")
+	procSCardReleaseContext   = winscard.NewProc("SCardReleaseContext")
+	procSCardConnectW         = winscard.NewProc("SCardConnectW")
+	procSCardDisconnect       = winscard.NewProc("SCardDisconnect")
+	procSCardBeginTransaction = winscard.NewProc("SCardBeginTransaction")
+	procSCardEndTransaction   = winscard.NewProc("SCardEndTransaction")
+	procSCardTransmit         = winscard.NewProc("SCardTransmit")
+)
+
+const (
+	scardScopeSystem      = 2
+	scardShareExclusive   = 1
+	scardLeaveCard        = 0
+	scardProtocolT1       = 2
+	scardPCIT1            = 0
+	maxBufferSizeExtended = (4 + 3 + (1 << 16) + 3 + 2)
+	rcSuccess             = 0
+)
+
+func scCheck(rc uintptr) error {
+	if rc == rcSuccess {
+		return nil
+	}
+	return &scErr{int64(rc)}
+}
+
+func isRCNoReaders(rc uintptr) bool {
+	return rc == 0x8010002E
+}
+
+type scContext struct {
+	ctx syscall.Handle
+}
+
+func newSCContext() (*scContext, error) {
+	var ctx syscall.Handle
+
+	r0, _, _ := procSCardEstablishContext.Call(
+		uintptr(scardScopeSystem),
+		uintptr(0),
+		uintptr(0),
+		uintptr(unsafe.Pointer(&ctx)),
+	)
+	if err := scCheck(r0); err != nil {
+		return nil, err
+	}
+	return &scContext{ctx: ctx}, nil
+}
+
+func (c *scContext) Close() error {
+	r0, _, _ := procSCardReleaseContext.Call(uintptr(c.ctx))
+	return scCheck(r0)
+}
+
+func (c *scContext) ListReaders() ([]string, error) {
+	var n uint32
+	r0, _, _ := procSCardListReadersW.Call(
+		uintptr(c.ctx),
+		uintptr(unsafe.Pointer(nil)),
+		uintptr(unsafe.Pointer(nil)),
+		uintptr(unsafe.Pointer(&n)),
+	)
+
+	if isRCNoReaders(r0) {
+		return nil, nil
+	}
+
+	if err := scCheck(r0); err != nil {
+		return nil, err
+	}
+
+	d := make([]uint16, n)
+	r0, _, _ = procSCardListReadersW.Call(
+		uintptr(c.ctx),
+		uintptr(unsafe.Pointer(nil)),
+		uintptr(unsafe.Pointer(&d[0])),
+		uintptr(unsafe.Pointer(&n)),
+	)
+	if err := scCheck(r0); err != nil {
+		return nil, err
+	}
+
+	var readers []string
+	j := 0
+	for i := 0; i < len(d); i++ {
+		if d[i] != 0 {
+			continue
+		}
+		readers = append(readers, syscall.UTF16ToString(d[j:i]))
+		j = i + 1
+
+		if d[i+1] == 0 {
+			break
+		}
+	}
+
+	return readers, nil
+}
+
+func (c *scContext) Connect(reader string) (*scHandle, error) {
+	var (
+		handle         syscall.Handle
+		activeProtocol uint16
+	)
+	r0, _, _ := procSCardConnectW.Call(
+		uintptr(c.ctx),
+		uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(reader))),
+		scardShareExclusive,
+		scardProtocolT1,
+		uintptr(unsafe.Pointer(&handle)),
+		uintptr(activeProtocol),
+	)
+	if err := scCheck(r0); err != nil {
+		return nil, err
+	}
+	return &scHandle{handle}, nil
+}
+
+type scHandle struct {
+	handle syscall.Handle
+}
+
+func (h *scHandle) Close() error {
+	r0, _, _ := procSCardDisconnect.Call(uintptr(h.handle), scardLeaveCard)
+	return scCheck(r0)
+}
+
+func (h *scHandle) Begin() (*scTx, error) {
+	r0, _, _ := procSCardBeginTransaction.Call(uintptr(h.handle))
+	if err := scCheck(r0); err != nil {
+		return nil, err
+	}
+	return &scTx{h.handle}, nil
+}
+
+func (t *scTx) Close() error {
+	r0, _, _ := procSCardEndTransaction.Call(uintptr(t.handle), scardLeaveCard)
+	return scCheck(r0)
+}
+
+type scTx struct {
+	handle syscall.Handle
+}
+
+func (t *scTx) transmit(req []byte) (more bool, b []byte, err error) {
+	var resp [maxBufferSizeExtended]byte
+	reqN := len(req)
+	respN := len(resp)
+	r0, _, _ := procSCardTransmit.Call(
+		uintptr(t.handle),
+		uintptr(scardPCIT1),
+		uintptr(unsafe.Pointer(&req[0])),
+		uintptr(reqN),
+		uintptr(0),
+		uintptr(unsafe.Pointer(&resp[0])),
+		uintptr(unsafe.Pointer(&respN)),
+	)
+
+	if err := scCheck(r0); err != nil {
+		return false, nil, fmt.Errorf("transmitting request: %w", err)
+	}
+	if respN < 2 {
+		return false, nil, fmt.Errorf("scard response too short: %d", respN)
+	}
+	sw1 := resp[respN-2]
+	sw2 := resp[respN-1]
+	if sw1 == 0x90 && sw2 == 0x00 {
+		return false, resp[:respN-2], nil
+	}
+	if sw1 == 0x61 {
+		return true, resp[:respN-2], nil
+	}
+	return false, nil, &apduErr{sw1, sw2}
+}


### PR DESCRIPTION
Adds support for windows via winscard. This CL leverages the
winscard api via calling into the dll. For more information
see https://docs.microsoft.com/en-us/windows/win32/api/winscard/.

Fixes #56 