### PR TITLE
piv: fixes for older YubiKey versions

### DIFF
--- a/piv/piv_test.go
+++ b/piv/piv_test.go
@@ -41,6 +41,13 @@ func testGetVersion(t *testing.T, h *scHandle) {
 	}
 }
 
+func testRequiresVersion(t *testing.T, yk *YubiKey, major, minor, patch int) {
+	v := yk.Version()
+	if v.Major < major || v.Minor < minor || v.Patch < patch {
+		t.Skipf("test requires yubikey version %d.%d.%d: got %d.%d.%d", major, minor, patch, v.Major, v.Minor, v.Patch)
+	}
+}
+
 func TestGetVersion(t *testing.T) { runHandleTest(t, testGetVersion) }
 
 func TestCards(t *testing.T) {
@@ -130,6 +137,9 @@ func TestYubiKeySerial(t *testing.T) {
 func TestYubiKeyLoginNeeded(t *testing.T) {
 	yk, close := newTestYubiKey(t)
 	defer close()
+
+	testRequiresVersion(t, yk, 4, 3, 0)
+
 	if !ykLoginNeeded(yk.tx) {
 		t.Errorf("expected login needed")
 	}


### PR DESCRIPTION
This change:
* Introduces a fallback when creating a PrivateKey if the YubiKey
  doesn't support attestation certificates.
* Fixes tests for older YubiKeys.
* Notes a bug in PIN caching for older YubiKeys.

Despite the spec[1], older YubiKeys don't let you determine if a PIN is
or isn't needed. This makes it impossible for the package to figure out
if a PIN is cached or we need to prompt. Add a BUG comment warning
against PINPolicyOnce for older YubiKeys.

[1]
https://csrc.nist.gov/CSRC/media/Publications/sp/800-73/4/archive/2015-05-29/documents/sp800_73-4_pt2_draft.pdf#page=20

Fixes #55