### PR TITLE
piv: add yubikey 5ci form factor

### DIFF
--- a/piv/key.go
+++ b/piv/key.go
@@ -66,6 +66,7 @@ const (
 	FormfactorUSBANano
 	FormfactorUSBCKeychain
 	FormfactorUSBCNano
+	FormfactorUSBCLightningKeychain
 )
 
 // Attestation returns additional information about a key attested to be on a
@@ -142,6 +143,8 @@ func (a *Attestation) addExt(e pkix.Extension) error {
 			a.Formfactor = FormfactorUSBCKeychain
 		case 0x04:
 			a.Formfactor = FormfactorUSBCNano
+		case 0x05:
+			a.Formfactor = FormfactorUSBCLightningKeychain
 		default:
 			return fmt.Errorf("unrecognized formfactor: 0x%x", e.Value[0])
 		}


### PR DESCRIPTION
This is the pull request for the issue mentioned in #62. The only change between the patch mentioned there and the one here is the renaming of `FormfactorUSBCLightning` to `FormfactorUSBCLightningKeychain` to make it fit the existing format. I'm not totally sure what the best name would be given that the device has two connectors.

Thanks!