### PR TITLE
piv: let user specify pin policy instead of using attestation cert

### DIFF
--- a/piv/key_test.go
+++ b/piv/key_test.go
@@ -93,8 +93,6 @@ func TestPINPrompt(t *testing.T) {
 			yk, close := newTestYubiKey(t)
 			defer close()
 
-			testRequiresVersion(t, yk, 4, 3, 0)
-
 			k := Key{
 				Algorithm:   AlgorithmEC256,
 				PINPolicy:   test.policy,
@@ -111,6 +109,11 @@ func TestPINPrompt(t *testing.T) {
 					return DefaultPIN, nil
 				},
 			}
+
+			if !supportsAttestation(yk) {
+				auth.PINPolicy = test.policy
+			}
+
 			priv, err := yk.PrivateKey(SlotAuthentication, pub, auth)
 			if err != nil {
 				t.Fatalf("building private key: %v", err)


### PR DESCRIPTION
I'm still seeing issues with my older YubiKey, but it looks like it's
not respecting the pin policy on the generated key. For example,
settings PINPolicyNone results in a "security condition not satisfied"
error.

Updates https://github.com/go-piv/piv-go/issues/60