### PR TITLE
Add FreeBSD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,12 @@ sudo yum config-manager --set-enabled PowerTools
 sudo yum install pcsc-lite-devel
 ```
 
+On FreeBSD:
+
+```
+sudo pkg install pcsc-lite
+```
+
 On Windows:
 
 No prerequisites are needed. The default driver by Microsoft supports all functionalities

--- a/piv/pcsc_freebsd.go
+++ b/piv/pcsc_freebsd.go
@@ -1,0 +1,30 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package piv
+
+import "C"
+
+// Return codes for PCSC are different on different platforms (int vs. long).
+
+func scCheck(rc C.long) error {
+	if rc == rcSuccess {
+		return nil
+	}
+	return &scErr{int64(rc)}
+}
+
+func isRCNoReaders(rc C.long) bool {
+	return rc == 0x8010002E
+}

--- a/piv/pcsc_unix.go
+++ b/piv/pcsc_unix.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build darwin linux
+// +build darwin linux freebsd
 
 package piv
 
@@ -23,6 +23,10 @@ package piv
 // #cgo darwin LDFLAGS: -framework PCSC
 // #cgo linux CFLAGS: -I/usr/include/PCSC
 // #cgo linux LDFLAGS: -lpcsclite
+// #cgo freebsd CFLAGS: -I/usr/local/include/
+// #cgo freebsd CFLAGS: -I/usr/local/include/PCSC
+// #cgo freebsd LDFLAGS: -L/usr/local/lib/
+// #cgo freebsd LDFLAGS: -lpcsclite
 // #include <PCSC/winscard.h>
 // #include <PCSC/wintypes.h>
 import "C"


### PR DESCRIPTION
Adds files/options to build the module on FreeBSD. 

Tested on FreeBSD 12.1-RELEASE with Yubikey 4 using go test -v ./piv --wipe-yubikey command