### PR TITLE
Add Retired Key Management Slots

### DIFF
--- a/piv/key.go
+++ b/piv/key.go
@@ -244,6 +244,44 @@ var (
 	slotAttestation = Slot{0xf9, 0x5fff01}
 )
 
+var retiredKeyManagementSlots = map[uint32]Slot{
+	0x82: {0x82, 0x5fc10d},
+	0x83: {0x83, 0x5fc10e},
+	0x84: {0x84, 0x5fc10f},
+	0x85: {0x85, 0x5fc110},
+	0x86: {0x86, 0x5fc111},
+	0x87: {0x87, 0x5fc112},
+	0x88: {0x88, 0x5fc113},
+	0x89: {0x89, 0x5fc114},
+	0x8a: {0x8a, 0x5fc115},
+	0x8b: {0x8b, 0x5fc116},
+	0x8c: {0x8c, 0x5fc117},
+	0x8d: {0x8d, 0x5fc118},
+	0x8e: {0x8e, 0x5fc119},
+	0x8f: {0x8f, 0x5fc11a},
+	0x90: {0x90, 0x5fc11b},
+	0x91: {0x91, 0x5fc11c},
+	0x92: {0x92, 0x5fc11d},
+	0x93: {0x93, 0x5fc11e},
+	0x94: {0x94, 0x5fc11f},
+	0x95: {0x95, 0x5fc120},
+}
+
+// RetiredKeyManagementSlot provides access to "retired" slots. Slots meant for old Key Management
+// keys that have been rotated. YubiKeys 4 and later support values between 0x82 and 0x95 (inclusive).
+//
+//     slot, ok := RetiredKeyManagementSlot(0x82)
+//     if !ok {
+//         // unrecognized slot
+//     }
+//     pub, err := yk.GenerateKey(managementKey, slot, key)
+//
+// https://developers.yubico.com/PIV/Introduction/Certificate_slots.html#_slot_82_95_retired_key_management
+func RetiredKeyManagementSlot(key uint32) (Slot, bool) {
+	slot, ok := retiredKeyManagementSlots[key]
+	return slot, ok
+}
+
 // Algorithm represents a specific algorithm and bit size supported by the PIV
 // specification.
 type Algorithm int

--- a/piv/key_test.go
+++ b/piv/key_test.go
@@ -579,3 +579,48 @@ func TestYubiKeyPrivateKeyPINError(t *testing.T) {
 		t.Errorf("expected sign to fail with pin prompt that returned error")
 	}
 }
+
+func TestRetiredKeyManagementSlot(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      uint32
+		wantSlot Slot
+		wantOk   bool
+	}{
+		{
+			name:     "Non-existent slot, before range",
+			key:      0x0,
+			wantSlot: Slot{},
+			wantOk:   false,
+		},
+		{
+			name:     "Non-existent slot, after range",
+			key:      0x96,
+			wantSlot: Slot{},
+			wantOk:   false,
+		},
+		{
+			name:     "First retired slot key",
+			key:      0x82,
+			wantSlot: Slot{0x82, 0x5fc10d},
+			wantOk:   true,
+		},
+		{
+			name:     "Last retired slot key",
+			key:      0x95,
+			wantSlot: Slot{0x95, 0x5fc120},
+			wantOk:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotSlot, gotOk := RetiredKeyManagementSlot(tt.key)
+			if gotSlot != tt.wantSlot {
+				t.Errorf("RetiredKeyManagementSlot() got = %v, want %v", gotSlot, tt.wantSlot)
+			}
+			if gotOk != tt.wantOk {
+				t.Errorf("RetiredKeyManagementSlot() got1 = %v, want %v", gotOk, tt.wantOk)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This Pull Request adds constants for the Retired Key Management slots of the YubiKey 5 series. This allows the possibility of using more key slots using this library.