### PR TITLE
Remove confusing word from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 This is not an officially supported Google product
 
-# A pure Go YubiKey PIV implementation
+# A Go YubiKey PIV implementation
 
 [![GoDoc](https://godoc.org/github.com/go-piv/piv-go/piv?status.svg)](https://godoc.org/github.com/go-piv/piv-go/piv)
 


### PR DESCRIPTION
Previously the README said this was a 'pure Go' implementation
which usually implies no cgo. Since this package wraps c libraries
(pcsc, etc.) this was a bit confusing. Remove the word 'pure'
to avoid that confusion.