### PR TITLE
fix: overflows _Ctype_long on linux x32

### DIFF
--- a/piv/pcsc_linux.go
+++ b/piv/pcsc_linux.go
@@ -26,5 +26,5 @@ func scCheck(rc C.long) error {
 }
 
 func isRCNoReaders(rc C.long) bool {
-	return rc == 0x8010002E
+	return C.ulong(rc) == 0x8010002E
 }


### PR DESCRIPTION
force go to use ulong on x32 ARCH