### PR TITLE
Fix build on OpenBSD

### DIFF
--- a/piv/pcsc_openbsd.go
+++ b/piv/pcsc_openbsd.go
@@ -1,0 +1,30 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package piv
+
+import "C"
+
+// Return codes for PCSC are different on different platforms (int vs. long).
+
+func scCheck(rc C.long) error {
+	if rc == rcSuccess {
+		return nil
+	}
+	return &scErr{int64(rc)}
+}
+
+func isRCNoReaders(rc C.long) bool {
+	return rc == 0x8010002E
+}

--- a/piv/pcsc_unix.go
+++ b/piv/pcsc_unix.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build darwin || linux || freebsd
-// +build darwin linux freebsd
+//go:build darwin || linux || freebsd || openbsd
+// +build darwin linux freebsd openbsd
 
 package piv
 
@@ -25,6 +25,10 @@ package piv
 // #cgo freebsd CFLAGS: -I/usr/local/include/PCSC
 // #cgo freebsd LDFLAGS: -L/usr/local/lib/
 // #cgo freebsd LDFLAGS: -lpcsclite
+// #cgo openbsd CFLAGS: -I/usr/local/include/
+// #cgo openbsd CFLAGS: -I/usr/local/include/PCSC
+// #cgo openbsd LDFLAGS: -L/usr/local/lib/
+// #cgo openbsd LDFLAGS: -lpcsclite
 // #include <PCSC/winscard.h>
 // #include <PCSC/wintypes.h>
 import "C"


### PR DESCRIPTION
This teaches Go where OpenBSD keeps the pcsc bits.