### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ if err := yk.SetMetadata(newKey, m); err != nil {
 fmt.Println("Credentials set. Your PIN is: %s", newPIN)
 ```
 
-The user can user the PIN later to fetch the management key:
+The user can use the PIN later to fetch the management key:
 
 ```go
 m, err := yk.Metadata(pin)


### PR DESCRIPTION
Change the sentence "The user can **user** the PIN later to fetch the management key" to "The user can **use** the PIN later to fetch the management key"