### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/go-piv/piv-go
 
-go 1.16
+go 1.18


### PR DESCRIPTION
Per #120

Go is presently `1.20` so should bump `go.mod` to _at least_ `1.18`  (20 - 2, per Go release support policy).