### PR TITLE
piv: implement key metadata retrieval

### DIFF
--- a/piv/key_test.go
+++ b/piv/key_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"crypto"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
@@ -31,6 +32,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -1137,4 +1139,219 @@ func TestVerify(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestKeyInfo(t *testing.T) {
+	func() {
+		yk, close := newTestYubiKey(t)
+		defer close()
+
+		testRequiresVersion(t, yk, 5, 3, 0)
+
+		if err := yk.Reset(); err != nil {
+			t.Fatalf("resetting key: %v", err)
+		}
+	}()
+
+	tests := []struct {
+		name      string
+		slot      Slot
+		importKey privateKey
+		policy    Key
+	}{
+		{
+			"Generated ec_256",
+			SlotAuthentication,
+			nil,
+			Key{AlgorithmEC256, PINPolicyNever, TouchPolicyNever},
+		},
+		{
+			"Generated ec_384",
+			SlotAuthentication,
+			nil,
+			Key{AlgorithmEC384, PINPolicyNever, TouchPolicyNever},
+		},
+		{
+			"Generated rsa_1024",
+			SlotAuthentication,
+			nil,
+			Key{AlgorithmRSA1024, PINPolicyNever, TouchPolicyNever},
+		},
+		{
+			"Generated rsa_2048",
+			SlotAuthentication,
+			nil,
+			Key{AlgorithmRSA2048, PINPolicyNever, TouchPolicyNever},
+		},
+		{
+			"Imported ec_256",
+			SlotAuthentication,
+			ephemeralKey(t, AlgorithmEC256),
+			Key{AlgorithmEC256, PINPolicyNever, TouchPolicyNever},
+		},
+		{
+			"Imported ec_384",
+			SlotAuthentication,
+			ephemeralKey(t, AlgorithmEC384),
+			Key{AlgorithmEC384, PINPolicyNever, TouchPolicyNever},
+		},
+		{
+			"Imported rsa_1024",
+			SlotAuthentication,
+			ephemeralKey(t, AlgorithmRSA1024),
+			Key{AlgorithmRSA1024, PINPolicyNever, TouchPolicyNever},
+		},
+		{
+			"Imported rsa_2048",
+			SlotAuthentication,
+			ephemeralKey(t, AlgorithmRSA2048),
+			Key{AlgorithmRSA2048, PINPolicyNever, TouchPolicyNever},
+		},
+		{
+			"PINPolicyOnce",
+			SlotAuthentication,
+			nil,
+			Key{AlgorithmEC256, PINPolicyOnce, TouchPolicyNever},
+		},
+		{
+			"PINPolicyAlways",
+			SlotAuthentication,
+			nil,
+			Key{AlgorithmEC256, PINPolicyAlways, TouchPolicyNever},
+		},
+		{
+			"TouchPolicyAlways",
+			SlotAuthentication,
+			nil,
+			Key{AlgorithmEC256, PINPolicyNever, TouchPolicyAlways},
+		},
+		{
+			"TouchPolicyCached",
+			SlotAuthentication,
+			nil,
+			Key{AlgorithmEC256, PINPolicyNever, TouchPolicyCached},
+		},
+		{
+			"SlotSignature",
+			SlotSignature,
+			nil,
+			Key{AlgorithmEC256, PINPolicyNever, TouchPolicyCached},
+		},
+		{
+			"SlotCardAuthentication",
+			SlotCardAuthentication,
+			nil,
+			Key{AlgorithmEC256, PINPolicyNever, TouchPolicyCached},
+		},
+		{
+			"SlotKeyManagement",
+			SlotKeyManagement,
+			nil,
+			Key{AlgorithmEC256, PINPolicyNever, TouchPolicyCached},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			yk, close := newTestYubiKey(t)
+			defer close()
+
+			want := KeyInfo{
+				Algorithm:   test.policy.Algorithm,
+				PINPolicy:   test.policy.PINPolicy,
+				TouchPolicy: test.policy.TouchPolicy,
+			}
+
+			if test.importKey == nil {
+				pub, err := yk.GenerateKey(DefaultManagementKey, test.slot, test.policy)
+				if err != nil {
+					t.Fatalf("generating key: %v", err)
+				}
+				want.Origin = OriginGenerated
+				want.PublicKey = pub
+			} else {
+				err := yk.SetPrivateKeyInsecure(DefaultManagementKey, test.slot, test.importKey, test.policy)
+				if err != nil {
+					t.Fatalf("importing key: %v", err)
+				}
+				want.Origin = OriginImported
+				want.PublicKey = test.importKey.Public()
+			}
+
+			got, err := yk.KeyInfo(test.slot)
+			if err != nil {
+				t.Fatalf("KeyInfo() = _, %v", err)
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("KeyInfo() = %#v, want %#v", got, want)
+			}
+		})
+	}
+}
+
+// TestDerivePINPolicy checks that Yubikeys with version >= 5.3.0 use the
+// KeyInfo method to determine the pin policy, instead of the attestation
+// certificate.
+func TestPINPolicy(t *testing.T) {
+	func() {
+		yk, close := newTestYubiKey(t)
+		defer close()
+
+		testRequiresVersion(t, yk, 5, 3, 0)
+
+		if err := yk.Reset(); err != nil {
+			t.Fatalf("resetting key: %v", err)
+		}
+	}()
+
+	yk, close := newTestYubiKey(t)
+	defer close()
+
+	// for imported keys, using the attestation certificate to derive the PIN
+	// policy fails. So we check that pinPolicy succeeds with imported keys.
+	priv := ephemeralKey(t, AlgorithmEC256)
+	err := yk.SetPrivateKeyInsecure(DefaultManagementKey, SlotAuthentication, priv, Key{
+		Algorithm:   AlgorithmEC256,
+		PINPolicy:   PINPolicyNever,
+		TouchPolicy: TouchPolicyNever,
+	})
+	if err != nil {
+		t.Fatalf("import key: %v", err)
+	}
+	if got, err := pinPolicy(yk, SlotAuthentication); err != nil || got != PINPolicyNever {
+		t.Fatalf("pinPolicy() = %v, %v, want %v, <nil>", got, err, PINPolicyNever)
+	}
+}
+
+// privateKey is an interface with the optional (but always supported) methods
+// of crypto.PrivateKey.
+type privateKey interface {
+	Equal(crypto.PrivateKey) bool
+	Public() crypto.PublicKey
+}
+
+// ephemeralKey generates an ephemeral key for the given algorithm.
+func ephemeralKey(t *testing.T, alg Algorithm) privateKey {
+	t.Helper()
+	var (
+		key privateKey
+		err error
+	)
+	switch alg {
+	case AlgorithmEC256:
+		key, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	case AlgorithmEC384:
+		key, err = ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	case AlgorithmEd25519:
+		_, key, err = ed25519.GenerateKey(rand.Reader)
+	case AlgorithmRSA1024:
+		key, err = rsa.GenerateKey(rand.Reader, 1024)
+	case AlgorithmRSA2048:
+		key, err = rsa.GenerateKey(rand.Reader, 2048)
+	default:
+		t.Fatalf("ephemeral key: unknown algorithm %d", alg)
+	}
+	if err != nil {
+		t.Fatalf("ephemeral key: %v", err)
+	}
+	return key
 }

--- a/piv/piv.go
+++ b/piv/piv.go
@@ -93,6 +93,7 @@ const (
 	insSetPINRetries = 0xfa
 	insAttest        = 0xf9
 	insGetSerial     = 0xf8
+	insGetMetadata   = 0xf7
 )
 
 // YubiKey is an exclusive open connection to a YubiKey smart card. While open,
@@ -807,4 +808,14 @@ func ykSetProtectedMetadata(tx *scTx, key [24]byte, m *Metadata) error {
 		return fmt.Errorf("command failed: %w", err)
 	}
 	return nil
+}
+
+func supportsVersion(v Version, major, minor, patch int) bool {
+	if v.Major != major {
+		return v.Major > major
+	}
+	if v.Minor != minor {
+		return v.Minor > minor
+	}
+	return v.Patch >= patch
 }

--- a/piv/piv_test.go
+++ b/piv/piv_test.go
@@ -49,16 +49,6 @@ func testGetVersion(t *testing.T, h *scHandle) {
 	}
 }
 
-func supportsVersion(v Version, major, minor, patch int) bool {
-	if v.Major != major {
-		return v.Major > major
-	}
-	if v.Minor != minor {
-		return v.Minor > minor
-	}
-	return v.Patch >= patch
-}
-
 func testRequiresVersion(t *testing.T, yk *YubiKey, major, minor, patch int) {
 	v := yk.Version()
 	if !supportsVersion(v, major, minor, patch) {


### PR DESCRIPTION
Add support for a YubiKey vendor extension to retrieve public metadata (including the public key, PIN/Touch policies and whether or not the key was hardware generated) for a given key slot.

Also use this new method to determine the pin policy, for YubiKeys that support it. This is more general than using the attestation certificate, as it also works for keys that have been generated offline and imported into the hardware token.

Fixes #129