### PR TITLE
Cleanups

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.19.x, 1.20.x]
+        go-version: [1.20.x, 1.21.x]
     name: Linux
     runs-on: ubuntu-latest
     steps:
@@ -29,7 +29,7 @@ jobs:
   build-windows:
     strategy:
       matrix:
-        go-version: [1.19.x, 1.20.x]
+        go-version: [1.20.x, 1.21.x]
     name: Windows
     runs-on: windows-latest
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
     - name: Install libpcsc
       run: sudo apt-get install -y libpcsclite-dev pcscd pcsc-tools
     - name: Test
-      run: "make test"
+      run: go test -v ./...
   build-windows:
     strategy:
       matrix:
@@ -41,6 +41,6 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
     - name: Test
-      run: "make build"
+      run: go build ./...
       env:
         CGO_ENABLED: 0

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,0 @@
-.PHONY: test
-test:
-	go test -v ./...
-
-.PHONY: build
-build:
-	go build ./...

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-This is not an officially supported Google product
-
 # A Go YubiKey PIV implementation
+
+**Note:** This is not an officially supported Google product
 
 [![Reference](https://pkg.go.dev/badge/github.com/go-piv/piv-go)](https://pkg.go.dev/github.com/go-piv/piv-go)
 
@@ -9,7 +9,7 @@ This applet is a simpler alternative to GPG for managing asymmetric keys on a
 YubiKey.
 
 This package is an alternative to Paul Tagliamonte's [go-ykpiv](https://github.com/paultag/go-ykpiv),
-a wrapper for YubiKey's ykpiv.h C library. This package aims to provide:
+a wrapper for YubiKey's `ykpiv.h` C library. This package aims to provide:
 
 * Better error messages
 * Idiomatic Go APIs
@@ -34,38 +34,38 @@ new EC key on the smart card, and provides a signing interface:
 // List all smart cards connected to the system.
 cards, err := piv.Cards()
 if err != nil {
-	// ...
+    // ...
 }
 
 // Find a YubiKey and open the reader.
 var yk *piv.YubiKey
 for _, card := range cards {
-	if strings.Contains(strings.ToLower(card), "yubikey") {
-		if yk, err = piv.Open(card); err != nil {
-			// ...
-		}
-		break
-	}
+    if strings.Contains(strings.ToLower(card), "yubikey") {
+        if yk, err = piv.Open(card); err != nil {
+            // ...
+        }
+        break
+    }
 }
 if yk == nil {
-	// ...
+    // ...
 }
 
 // Generate a private key on the YubiKey.
 key := piv.Key{
-	Algorithm:   piv.AlgorithmEC256,
-	PINPolicy:   piv.PINPolicyAlways,
-	TouchPolicy: piv.TouchPolicyAlways,
+    Algorithm:   piv.AlgorithmEC256,
+    PINPolicy:   piv.PINPolicyAlways,
+    TouchPolicy: piv.TouchPolicyAlways,
 }
 pub, err := yk.GenerateKey(piv.DefaultManagementKey, piv.SlotAuthentication, key)
 if err != nil {
-	// ...
+    // ...
 }
 
 auth := piv.KeyAuth{PIN: piv.DefaultPIN}
 priv, err := yk.PrivateKey(piv.SlotAuthentication, pub, auth)
 if err != nil {
-	// ...
+    // ...
 }
 // Use private key to sign or decrypt.
 ```
@@ -88,15 +88,15 @@ The following code generates new, random credentials for a YubiKey:
 ```go
 newPINInt, err := rand.Int(rand.Reader, big.NewInt(1_000_000))
 if err != nil {
-	// ...
+    // ...
 }
 newPUKInt, err := rand.Int(rand.Reader, big.NewInt(100_000_000))
 if err != nil {
-	// ...
+    // ...
 }
 var newKey [24]byte
 if _, err := io.ReadFull(rand.Reader, newKey[:]); err != nil {
-	// ...
+    // ...
 }
 // Format with leading zeros.
 newPIN := fmt.Sprintf("%06d", newPINInt)
@@ -104,18 +104,18 @@ newPUK := fmt.Sprintf("%08d", newPUKInt)
 
 // Set all values to a new value.
 if err := yk.SetManagementKey(piv.DefaultManagementKey, newKey); err != nil {
-	// ...
+    // ...
 }
 if err := yk.SetPUK(piv.DefaultPUK, newPUK); err != nil {
-	// ...
+    // ...
 }
 if err := yk.SetPIN(piv.DefaultPIN, newPIN); err != nil {
-	// ...
+    // ...
 }
 // Store management key on the YubiKey.
 m := piv.Metadata{ManagementKey: &newKey}
 if err := yk.SetMetadata(newKey, m); err != nil {
-	// ...
+    // ...
 }
 
 fmt.Println("Credentials set. Your PIN is: %s", newPIN)
@@ -126,10 +126,10 @@ The user can use the PIN later to fetch the management key:
 ```go
 m, err := yk.Metadata(pin)
 if err != nil {
-	// ...
+    // ...
 }
 if m.ManagementKey == nil {
-	// ...
+    // ...
 }
 key := *m.ManagementKey
 ```
@@ -141,35 +141,35 @@ The PIV applet can also store X.509 certificates on the YubiKey:
 ```go
 cert, err := x509.ParseCertificate(certDER)
 if err != nil {
-	// ...
+    // ...
 }
 if err := yk.SetCertificate(managementKey, piv.SlotAuthentication, cert); err != nil {
-	// ...
+    // ...
 }
 ```
 
 The certificate can later be used in combination with the private key. For
-example, to serve TLS traffic: 
+example, to serve TLS traffic:
 
 ```go
 cert, err := yk.Certificate(piv.SlotAuthentication)
 if err != nil {
-	// ...
+    // ...
 }
 priv, err := yk.PrivateKey(piv.SlotAuthentication, cert.PublicKey, auth)
 if err != nil {
-	// ...
+    // ...
 }
 s := &http.Server{
-	TLSConfig: &tls.Config{
-		Certificates: []tls.Certificate{
-			{
-				Certificate: [][]byte{cert.Raw},
-				PrivateKey:  priv,
-			},
-		},
-	},
-	Handler: myHandler,
+    TLSConfig: &tls.Config{
+        Certificates: []tls.Certificate{
+            {
+                Certificate: [][]byte{cert.Raw},
+                PrivateKey:  priv,
+            },
+        },
+    },
+    Handler: myHandler,
 }
 ```
 
@@ -183,22 +183,22 @@ key, then asks the YubiKey to sign an attestation certificate:
 // Get the YubiKey's attestation certificate, which is signed by Yubico.
 yubiKeyAttestationCert, err := yk.AttestationCertificate()
 if err != nil {
-	// ...
+    // ...
 }
 
 // Generate a key on the YubiKey and generate an attestation certificate for
 // that key. This will be signed by the YubiKey's attestation certificate.
 key := piv.Key{
-	Algorithm:   piv.AlgorithmEC256,
-	PINPolicy:   piv.PINPolicyAlways,
-	TouchPolicy: piv.TouchPolicyAlways,
+    Algorithm:   piv.AlgorithmEC256,
+    PINPolicy:   piv.PINPolicyAlways,
+    TouchPolicy: piv.TouchPolicyAlways,
 }
 if _, err := yk.GenerateKey(managementKey, piv.SlotAuthentication, key); err != nil {
-	// ...
+    // ...
 }
 slotAttestationCertificate, err := yk.Attest(piv.SlotAuthentication)
 if err != nil {
-	// ...
+    // ...
 }
 
 // Send certificates to server.
@@ -212,10 +212,10 @@ and enforce policy:
 // YubiKey.
 a, err := piv.Verify(yubiKeyAttestationCert, slotAttestationCertificate)
 if err != nil {
-	// ...
+    // ...
 }
 if a.TouchPolicy != piv.TouchPolicyAlways {
-	// ...
+    // ...
 }
 
 // Record YubiKey's serial number and public key.
@@ -227,8 +227,8 @@ serial := a.Serial
 
 On MacOS, piv-go doesn't require any additional packages.
 
-To build on Linux, piv-go requires PCSC lite. To install on Debian-based
-distros, run:
+To build on Linux, piv-go requires PCSC lite.
+To install on Debian-based distributions, run:
 
 ```shell
 sudo apt-get install libpcsclite-dev
@@ -263,7 +263,7 @@ smart functionality_](https://www.yubico.com/authentication-standards/smart-card
 
 Please notice the following:
 
->Windows support is best effort due to lack of test hardware. This means the maintainers will take patches for Windows, but if you encounter a bug or the build is broken, you may be asked to fix it.
+> Windows support is best effort due to lack of test hardware. This means the maintainers will take patches for Windows, but if you encounter a bug or the build is broken, you may be asked to fix it.
 
 ## Non-YubiKey smart cards
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ This is not an officially supported Google product
 
 # A Go YubiKey PIV implementation
 
-[![GoDoc](https://godoc.org/github.com/go-piv/piv-go/piv?status.svg)](https://godoc.org/github.com/go-piv/piv-go/piv)
+[![Reference](https://pkg.go.dev/badge/github.com/go-piv/piv-go)](https://pkg.go.dev/github.com/go-piv/piv-go)
 
 YubiKeys implement the PIV specification for managing smart card certificates.
 This applet is a simpler alternative to GPG for managing asymmetric keys on a

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ The piv-go package can be used to generate keys and store certificates on a
 YubiKey. This uses a management key to generate new keys on the applet, and a
 PIN for signing operations. The package provides default PIN values. If the PIV
 credentials on the YubiKey haven't been modified, the follow code generates a
-new EC key on the smartcard, and provides a signing interface:
+new EC key on the smart card, and provides a signing interface:
 
 ```go
-// List all smartcards connected to the system.
+// List all smart cards connected to the system.
 cards, err := piv.Cards()
 if err != nil {
 	// ...
@@ -175,7 +175,7 @@ s := &http.Server{
 
 ### Attestation
 
-YubiKeys can attest that a particular key was generated on the smartcard, and
+YubiKeys can attest that a particular key was generated on the smart card, and
 that it was set with specific PIN and touch policies. The client generates a
 key, then asks the YubiKey to sign an attestation certificate:
 
@@ -265,9 +265,9 @@ Please notice the following:
 
 >Windows support is best effort due to lack of test hardware. This means the maintainers will take patches for Windows, but if you encounter a bug or the build is broken, you may be asked to fix it.
 
-## Non-YubiKey smartcards
+## Non-YubiKey smart cards
 
-Non-YubiKey smartcards that implement the PIV standard are not officially supported due to a lack of test hardware. However, PRs that fix integrations with other smartcards are welcome, and piv-go will attempt to not break that support.  
+Non-YubiKey smart cards that implement the PIV standard are not officially supported due to a lack of test hardware. However, PRs that fix integrations with other smart cards are welcome, and piv-go will attempt to not break that support.  
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -230,19 +230,19 @@ On MacOS, piv-go doesn't require any additional packages.
 To build on Linux, piv-go requires PCSC lite. To install on Debian-based
 distros, run:
 
-```
+```shell
 sudo apt-get install libpcsclite-dev
 ```
 
 On Fedora:
 
-```
+```shell
 sudo yum install pcsc-lite-devel
 ```
 
 On CentOS:
 
-```
+```shell
 sudo yum install 'dnf-command(config-manager)'
 sudo yum config-manager --set-enabled PowerTools
 sudo yum install pcsc-lite-devel
@@ -250,7 +250,7 @@ sudo yum install pcsc-lite-devel
 
 On FreeBSD:
 
-```
+```shell
 sudo pkg install pcsc-lite
 ```
 
@@ -275,13 +275,13 @@ Tests automatically find connected available YubiKeys, but won't modify the
 smart card without the `--wipe-yubikey` flag. To let the tests modify your
 YubiKey's PIV applet, run:
 
-```
+```shell
 go test -v ./piv --wipe-yubikey
 ```
 
 Longer tests can be skipped with the `--test.short` flag.
 
-```
+```shell
 go test -v --short ./piv --wipe-yubikey
 ```
 


### PR DESCRIPTION
This PR performs general maintenance and cleanups:

- Fix Markdown code smells via markdownlint
- Remove Makefile
- Update tests to currently supported Go versions
- Update old godoc.org links