### PR TITLE
close is a reserved word in go, rename close variables to closeFunc

### DIFF
--- a/piv/key_test.go
+++ b/piv/key_test.go
@@ -38,8 +38,8 @@ import (
 )
 
 func TestYubiKeySignECDSA(t *testing.T) {
-	yk, close := newTestYubiKey(t)
-	defer close()
+	yk, closeFunc := newTestYubiKey(t)
+	defer closeFunc()
 
 	if err := yk.Reset(); err != nil {
 		t.Fatalf("reset yubikey: %v", err)
@@ -85,8 +85,8 @@ func TestYubiKeySignECDSA(t *testing.T) {
 }
 
 func TestYubiKeyECDSASharedKey(t *testing.T) {
-	yk, close := newTestYubiKey(t)
-	defer close()
+	yk, closeFunc := newTestYubiKey(t)
+	defer closeFunc()
 
 	slot := SlotAuthentication
 
@@ -155,8 +155,8 @@ func TestPINPrompt(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			yk, close := newTestYubiKey(t)
-			defer close()
+			yk, closeFunc := newTestYubiKey(t)
+			defer closeFunc()
 
 			k := Key{
 				Algorithm:   AlgorithmEC256,
@@ -206,11 +206,11 @@ func supportsAttestation(yk *YubiKey) bool {
 }
 
 func TestSlots(t *testing.T) {
-	yk, close := newTestYubiKey(t)
+	yk, closeFunc := newTestYubiKey(t)
 	if err := yk.Reset(); err != nil {
 		t.Fatalf("resetting yubikey: %v", err)
 	}
-	close()
+	closeFunc()
 
 	tests := []struct {
 		name string
@@ -224,8 +224,8 @@ func TestSlots(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			yk, close := newTestYubiKey(t)
-			defer close()
+			yk, closeFunc := newTestYubiKey(t)
+			defer closeFunc()
 
 			if supportsAttestation(yk) {
 				if _, err := yk.Attest(test.slot); err == nil || !errors.Is(err, ErrNotFound) {
@@ -302,8 +302,8 @@ func TestYubiKeySignRSA(t *testing.T) {
 			if test.long && testing.Short() {
 				t.Skip("skipping test in short mode")
 			}
-			yk, close := newTestYubiKey(t)
-			defer close()
+			yk, closeFunc := newTestYubiKey(t)
+			defer closeFunc()
 			slot := SlotAuthentication
 			key := Key{
 				Algorithm:   test.alg,
@@ -352,8 +352,8 @@ func TestYubiKeySignRSAPSS(t *testing.T) {
 			if test.long && testing.Short() {
 				t.Skip("skipping test in short mode")
 			}
-			yk, close := newTestYubiKey(t)
-			defer close()
+			yk, closeFn := newTestYubiKey(t)
+			defer closeFn()
 			slot := SlotAuthentication
 			key := Key{
 				Algorithm:   test.alg,
@@ -391,8 +391,8 @@ func TestYubiKeySignRSAPSS(t *testing.T) {
 }
 
 func TestTLS13(t *testing.T) {
-	yk, close := newTestYubiKey(t)
-	defer close()
+	yk, closeFn := newTestYubiKey(t)
+	defer closeFn()
 	slot := SlotAuthentication
 	key := Key{
 		Algorithm:   AlgorithmRSA1024,
@@ -493,7 +493,7 @@ func TestTLS13(t *testing.T) {
 		defer conn.Close()
 
 		if v := conn.ConnectionState().Version; v != tls.VersionTLS13 {
-			errCh <- fmt.Errorf("client got verison 0x%x, want=0x%x", v, tls.VersionTLS13)
+			errCh <- fmt.Errorf("client got version 0x%x, want=0x%x", v, tls.VersionTLS13)
 			return
 		}
 
@@ -525,8 +525,8 @@ func TestYubiKeyDecryptRSA(t *testing.T) {
 			if test.long && testing.Short() {
 				t.Skip("skipping test in short mode")
 			}
-			yk, close := newTestYubiKey(t)
-			defer close()
+			yk, closeFunc := newTestYubiKey(t)
+			defer closeFunc()
 			slot := SlotAuthentication
 			key := Key{
 				Algorithm:   test.alg,
@@ -568,8 +568,8 @@ func TestYubiKeyDecryptRSA(t *testing.T) {
 }
 
 func TestYubiKeyAttestation(t *testing.T) {
-	yk, close := newTestYubiKey(t)
-	defer close()
+	yk, closeFunc := newTestYubiKey(t)
+	defer closeFunc()
 	key := Key{
 		Algorithm:   AlgorithmEC256,
 		PINPolicy:   PINPolicyNever,
@@ -621,8 +621,8 @@ func TestYubiKeyAttestation(t *testing.T) {
 }
 
 func TestYubiKeyStoreCertificate(t *testing.T) {
-	yk, close := newTestYubiKey(t)
-	defer close()
+	yk, closeFunc := newTestYubiKey(t)
+	defer closeFunc()
 	slot := SlotAuthentication
 
 	caPriv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -718,8 +718,8 @@ func TestYubiKeyGenerateKey(t *testing.T) {
 			if test.long && testing.Short() {
 				t.Skip("skipping test in short mode")
 			}
-			yk, close := newTestYubiKey(t)
-			defer close()
+			yk, closeFunc := newTestYubiKey(t)
+			defer closeFunc()
 			if test.alg == AlgorithmEC384 {
 				testRequiresVersion(t, yk, 4, 3, 0)
 			}
@@ -740,8 +740,8 @@ func TestYubiKeyPrivateKey(t *testing.T) {
 	alg := AlgorithmEC256
 	slot := SlotAuthentication
 
-	yk, close := newTestYubiKey(t)
-	defer close()
+	yk, closeFunc := newTestYubiKey(t)
+	defer closeFunc()
 
 	key := Key{
 		Algorithm:   alg,
@@ -789,8 +789,8 @@ func TestYubiKeyPrivateKeyPINError(t *testing.T) {
 	alg := AlgorithmEC256
 	slot := SlotAuthentication
 
-	yk, close := newTestYubiKey(t)
-	defer close()
+	yk, closeFunc := newTestYubiKey(t)
+	defer closeFunc()
 
 	key := Key{
 		Algorithm:   alg,
@@ -904,8 +904,8 @@ func TestSetRSAPrivateKey(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			yk, close := newTestYubiKey(t)
-			defer close()
+			yk, closeFunc := newTestYubiKey(t)
+			defer closeFunc()
 
 			generated, err := rsa.GenerateKey(rand.Reader, tt.bits)
 			if err != nil {
@@ -944,7 +944,8 @@ func TestSetRSAPrivateKey(t *testing.T) {
 				t.Fatalf("decrypting data: %v", err)
 			}
 
-			if !bytes.Equal(data, decrypted) {
+			// nolint:gosimple  // bytes.Equal does not behave the same here.
+			if bytes.Compare(data, decrypted) != 0 {
 				t.Fatalf("decrypted data is different to the source data")
 			}
 		})
@@ -986,8 +987,8 @@ func TestSetECDSAPrivateKey(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			yk, close := newTestYubiKey(t)
-			defer close()
+			yk, closeFunc := newTestYubiKey(t)
+			defer closeFunc()
 
 			generated, err := ecdsa.GenerateKey(tt.curve, rand.Reader)
 			if err != nil {

--- a/piv/piv_test.go
+++ b/piv/piv_test.go
@@ -91,8 +91,8 @@ func newTestYubiKey(t *testing.T) (*YubiKey, func()) {
 }
 
 func TestNewYubiKey(t *testing.T) {
-	_, close := newTestYubiKey(t)
-	defer close()
+	_, closeFunc := newTestYubiKey(t)
+	defer closeFunc()
 }
 
 func TestMultipleConnections(t *testing.T) {
@@ -134,8 +134,8 @@ func TestMultipleConnections(t *testing.T) {
 }
 
 func TestYubiKeySerial(t *testing.T) {
-	yk, close := newTestYubiKey(t)
-	defer close()
+	yk, closeFunc := newTestYubiKey(t)
+	defer closeFunc()
 
 	if _, err := yk.Serial(); err != nil {
 		t.Fatalf("getting serial number: %v", err)
@@ -143,8 +143,8 @@ func TestYubiKeySerial(t *testing.T) {
 }
 
 func TestYubiKeyLoginNeeded(t *testing.T) {
-	yk, close := newTestYubiKey(t)
-	defer close()
+	yk, closeFunc := newTestYubiKey(t)
+	defer closeFunc()
 
 	testRequiresVersion(t, yk, 4, 3, 0)
 
@@ -160,8 +160,8 @@ func TestYubiKeyLoginNeeded(t *testing.T) {
 }
 
 func TestYubiKeyPINRetries(t *testing.T) {
-	yk, close := newTestYubiKey(t)
-	defer close()
+	yk, closeFunc := newTestYubiKey(t)
+	defer closeFunc()
 	retries, err := yk.Retries()
 	if err != nil {
 		t.Fatalf("getting retries: %v", err)
@@ -175,8 +175,8 @@ func TestYubiKeyReset(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
-	yk, close := newTestYubiKey(t)
-	defer close()
+	yk, closeFunc := newTestYubiKey(t)
+	defer closeFunc()
 	if err := yk.Reset(); err != nil {
 		t.Fatalf("resetting yubikey: %v", err)
 	}
@@ -186,8 +186,8 @@ func TestYubiKeyReset(t *testing.T) {
 }
 
 func TestYubiKeyLogin(t *testing.T) {
-	yk, close := newTestYubiKey(t)
-	defer close()
+	yk, closeFunc := newTestYubiKey(t)
+	defer closeFunc()
 
 	if err := yk.VerifyPIN(DefaultPIN); err != nil {
 		t.Fatalf("login: %v", err)
@@ -195,8 +195,8 @@ func TestYubiKeyLogin(t *testing.T) {
 }
 
 func TestYubiKeyAuthenticate(t *testing.T) {
-	yk, close := newTestYubiKey(t)
-	defer close()
+	yk, closeFunc := newTestYubiKey(t)
+	defer closeFunc()
 
 	if err := yk.authManagementKey(DefaultManagementKey); err != nil {
 		t.Errorf("authenticating: %v", err)
@@ -204,8 +204,8 @@ func TestYubiKeyAuthenticate(t *testing.T) {
 }
 
 func TestYubiKeySetManagementKey(t *testing.T) {
-	yk, close := newTestYubiKey(t)
-	defer close()
+	yk, closeFunc := newTestYubiKey(t)
+	defer closeFunc()
 
 	var mgmtKey [24]byte
 	if _, err := io.ReadFull(rand.Reader, mgmtKey[:]); err != nil {
@@ -224,8 +224,8 @@ func TestYubiKeySetManagementKey(t *testing.T) {
 }
 
 func TestYubiKeyUnblockPIN(t *testing.T) {
-	yk, close := newTestYubiKey(t)
-	defer close()
+	yk, closeFunc := newTestYubiKey(t)
+	defer closeFunc()
 
 	badPIN := "0"
 	for {
@@ -251,8 +251,8 @@ func TestYubiKeyUnblockPIN(t *testing.T) {
 }
 
 func TestYubiKeyChangePIN(t *testing.T) {
-	yk, close := newTestYubiKey(t)
-	defer close()
+	yk, closeFunc := newTestYubiKey(t)
+	defer closeFunc()
 
 	newPIN := "654321"
 	if err := yk.SetPIN(newPIN, newPIN); err == nil {
@@ -267,8 +267,8 @@ func TestYubiKeyChangePIN(t *testing.T) {
 }
 
 func TestYubiKeyChangePUK(t *testing.T) {
-	yk, close := newTestYubiKey(t)
-	defer close()
+	yk, closeFunc := newTestYubiKey(t)
+	defer closeFunc()
 
 	newPUK := "87654321"
 	if err := yk.SetPUK(newPUK, newPUK); err == nil {
@@ -283,8 +283,8 @@ func TestYubiKeyChangePUK(t *testing.T) {
 }
 
 func TestChangeManagementKey(t *testing.T) {
-	yk, close := newTestYubiKey(t)
-	defer close()
+	yk, closeFunc := newTestYubiKey(t)
+	defer closeFunc()
 
 	var newKey [24]byte
 	if _, err := io.ReadFull(rand.Reader, newKey[:]); err != nil {
@@ -312,15 +312,15 @@ func TestMetadata(t *testing.T) {
 		t.Skip("skipping test in short mode.")
 	}
 	func() {
-		yk, close := newTestYubiKey(t)
-		defer close()
+		yk, closeFunc := newTestYubiKey(t)
+		defer closeFunc()
 		if err := yk.Reset(); err != nil {
 			t.Fatalf("resetting yubikey: %v", err)
 		}
 	}()
 
-	yk, close := newTestYubiKey(t)
-	defer close()
+	yk, closeFunc := newTestYubiKey(t)
+	defer closeFunc()
 
 	if m, err := yk.Metadata(DefaultPIN); err != nil {
 		t.Errorf("getting metadata: %v", err)


### PR DESCRIPTION
golangci-lint tripped over close being a reserved word, so this PR renames close to closeFunc, to avoid using reserved words.