### PR TITLE
Update to go 1.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,7 @@ test:
 .PHONY: build
 build:
 	go build ./...
+
+.PHONY: clean
+clean:
+	go clean ./...

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/go-piv/piv-go
 
-go 1.16
+go 1.18


### PR DESCRIPTION
Add clean target to Makefile

When I started on my fork, we were running go 1.18.
We're now using go 1.22, but I'm not sure if you would like to update the go version or leave it as 1.16 for compatibility.
I've been keeping my projects at latest, or N-1 at the latest.