### PR TITLE
Add generic Smartcard API

### DIFF
--- a/piv/smartcard.go
+++ b/piv/smartcard.go
@@ -1,0 +1,51 @@
+package piv
+
+import (
+	"fmt"
+)
+
+type Smartcard struct {
+	ctx *scContext
+	h   *scHandle
+	tx  *scTx
+}
+
+func OpenSmartcard(reader string) (*Smartcard, error) {
+	ctx, err := newSCContext()
+	if err != nil {
+		return nil, fmt.Errorf("connecting to smart card daemon: %w", err)
+	}
+
+	h, err := ctx.Connect(reader)
+	if err != nil {
+		ctx.Close()
+		return nil, fmt.Errorf("connecting to smart card: %w", err)
+	}
+	tx, err := h.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("beginning smart card transaction: %w", err)
+	}
+
+	return &Smartcard{ctx: ctx, h: h, tx: tx}, nil
+}
+
+func (sc *Smartcard) Transmit(apduRaw []byte) ([]byte, error) {
+	_, resp, err := sc.tx.transmit(apduRaw)
+	if err != nil {
+		return nil, fmt.Errorf("transmitting APDU: %w", err)
+	}
+	return resp, nil
+}
+
+func (sc *Smartcard) Close() error {
+	if sc.tx != nil {
+		sc.tx.Close()
+	}
+	if sc.h != nil {
+		sc.h.Close()
+	}
+	if sc.ctx != nil {
+		sc.ctx.Close()
+	}
+	return nil
+}


### PR DESCRIPTION
Hi,

we would like to use your great project to communicate with german healthcare smartcards (insurant, practitioner, institution). Therefore it would be great to have a generic Smartcard struct with some basic APDU API.

Later on we can contribute more features, like APDU-Builder, MF/EF Files, Certificates etc, if you like.

Thank you