### PR TITLE
Add dynamic support for AES128/192/256 management keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ if err != nil {
 The PIV applet has three unique credentials:
 
 * Management key (3DES key) used to generate new keys on the YubiKey.
+  * YubiKey firmware 5.4.0+ adds support for AES128/192/256 keys
 * PIN (up to 8 digits, usually 6) used to access signing operations.
 * PUK (up to 8 digits) used to unblock the PIN. Usually set once and thrown
   away or managed by an administrator.
@@ -103,7 +104,7 @@ newPIN := fmt.Sprintf("%06d", newPINInt)
 newPUK := fmt.Sprintf("%08d", newPUKInt)
 
 // Set all values to a new value.
-if err := yk.SetManagementKey(piv.DefaultManagementKey, newKey); err != nil {
+if err := yk.SetManagementKey(piv.DefaultManagementKey, newKey[:]); err != nil {
 	// ...
 }
 if err := yk.SetPUK(piv.DefaultPUK, newPUK); err != nil {
@@ -113,8 +114,8 @@ if err := yk.SetPIN(piv.DefaultPIN, newPIN); err != nil {
 	// ...
 }
 // Store management key on the YubiKey.
-m := piv.Metadata{ManagementKey: &newKey}
-if err := yk.SetMetadata(newKey, m); err != nil {
+m := piv.Metadata{ManagementKey: &newKey[:]}
+if err := yk.SetMetadata(newKey[:], m); err != nil {
 	// ...
 }
 

--- a/v2/piv/key_test.go
+++ b/v2/piv/key_test.go
@@ -202,7 +202,7 @@ func TestPINPrompt(t *testing.T) {
 }
 
 func supportsAttestation(yk *YubiKey) bool {
-	return supportsVersion(yk.Version(), 4, 3, 0)
+	return supportsVersion(yk.version, 4, 3, 0)
 }
 
 func TestSlots(t *testing.T) {


### PR DESCRIPTION
Add dynamic support for AES128/192/256 management keys, including setting them. Prefer AES192 over 3DES when possible.

This also fixes the issue introduced by the default management key type change in yubikeys 5.7.0+