### PR TITLE
Add ability to change allowed number of PIN and PUK retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,13 @@ if _, err := io.ReadFull(rand.Reader, newKey); err != nil {
 newPIN := fmt.Sprintf("%06d", newPINInt)
 newPUK := fmt.Sprintf("%08d", newPUKInt)
 
-// Set all values to a new value.
+// If you want to change PIN/PUK retries, it's recommended to do it BEFORE changing
+// the PIN/PUK, as SetRetries will reset PIN/PUK to their default values.
+if err := yk.SetRetries(piv.DefaultManagementKey, piv.DefaultPIN, 5, 4); err != nil {
+	// ...
+}
+
+// Set all values to a new value. 
 if err := yk.SetManagementKey(piv.DefaultManagementKey, newKey); err != nil {
 	// ...
 }

--- a/v2/piv/piv_test.go
+++ b/v2/piv/piv_test.go
@@ -281,6 +281,21 @@ func TestYubiKeyChangePUK(t *testing.T) {
 	}
 }
 
+func TestYubiKeyChangeRetries(t *testing.T) {
+	yk, close := newTestYubiKey(t)
+	defer close()
+
+	if err := yk.SetRetries(DefaultManagementKey, DefaultPIN, 3, 0); err == nil {
+		t.Errorf("successfully set retries to zeros, expected error")
+	}
+	if err := yk.SetRetries(DefaultManagementKey, DefaultPIN, 256, 3); err == nil {
+		t.Errorf("successfully set retries greater than 255, expected error")
+	}
+	if err := yk.SetRetries(DefaultManagementKey, DefaultPIN, 5, 3); err != nil {
+		t.Fatalf("setting pin/puk retries: %v", err)
+	}
+}
+
 func TestChangeManagementKey(t *testing.T) {
 	yk, close := newTestYubiKey(t)
 	defer close()


### PR DESCRIPTION
Add the ability to change PIN/PUK retries using SetRetries. Changing the retries does have the side effect on yubikeys of resetting the PIN and PUK to their default values, so I made sure that is very clear in the comments and README.