### PR TITLE
Ed25519 improvements

### DIFF
--- a/v2/piv/key.go
+++ b/v2/piv/key.go
@@ -440,8 +440,6 @@ type Algorithm int
 // Algorithms supported by this package. Note that not all cards will support
 // every algorithm.
 //
-// AlgorithmEd25519 is currently only implemented by SoloKeys.
-//
 // For algorithm discovery, see: https://github.com/ericchiang/piv-go/issues/1
 const (
 	AlgorithmEC256 Algorithm = iota + 1
@@ -1402,8 +1400,6 @@ func ykECDHX25519(tx *scTx, slot Slot, pub *ecdh.PublicKey, peer *ecdh.PublicKey
 	return sharedSecret, nil
 }
 
-// This function only works on SoloKeys prototypes and other PIV devices that choose
-// to implement Ed25519 signatures under alg 0x22.
 func skSignEd25519(tx *scTx, slot Slot, pub ed25519.PublicKey, digest []byte) ([]byte, error) {
 	// Adaptation of
 	// https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-73-4.pdf#page=118

--- a/v2/piv/key.go
+++ b/v2/piv/key.go
@@ -1297,7 +1297,7 @@ func (k *keyEd25519) Public() crypto.PublicKey {
 
 func (k *keyEd25519) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
 	return k.auth.do(k.yk, k.pp, func(tx *scTx) ([]byte, error) {
-		return skSignEd25519(tx, k.slot, k.pub, digest)
+		return ykSignEd25519(tx, k.slot, k.pub, digest)
 	})
 }
 
@@ -1400,7 +1400,7 @@ func ykECDHX25519(tx *scTx, slot Slot, pub *ecdh.PublicKey, peer *ecdh.PublicKey
 	return sharedSecret, nil
 }
 
-func skSignEd25519(tx *scTx, slot Slot, pub ed25519.PublicKey, digest []byte) ([]byte, error) {
+func ykSignEd25519(tx *scTx, slot Slot, pub ed25519.PublicKey, digest []byte) ([]byte, error) {
 	// Adaptation of
 	// https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-73-4.pdf#page=118
 	cmd := apdu{


### PR DESCRIPTION
This PR includes a few minor cleanups, and most importantly, returns an error if Ed25519ctx or Ed25519ph is requested. Previously, an invalid signature was being returned. As far as I can tell, the YubiKey does not support these Ed25519 variants.