### PR TITLE
Option to make yubikey connection shared

### DIFF
--- a/piv/pcsc_test.go
+++ b/piv/pcsc_test.go
@@ -63,7 +63,7 @@ func runHandleTest(t *testing.T, f func(t *testing.T, h *scHandle)) {
 		if reader == "" {
 			t.Skip("could not find yubikey, skipping testing")
 		}
-		h, err := c.Connect(reader)
+		h, err := c.Connect(reader, false)
 		if err != nil {
 			t.Fatalf("connecting to %s: %v", reader, err)
 		}

--- a/piv/pcsc_unix.go
+++ b/piv/pcsc_unix.go
@@ -92,13 +92,19 @@ type scHandle struct {
 	h C.SCARDHANDLE
 }
 
-func (c *scContext) Connect(reader string) (*scHandle, error) {
+func (c *scContext) Connect(reader string, shared bool) (*scHandle, error) {
 	var (
 		handle         C.SCARDHANDLE
 		activeProtocol C.DWORD
 	)
+
+    var mode C.ulong = C.SCARD_SHARE_EXCLUSIVE
+    if shared {
+        mode = C.SCARD_SHARE_SHARED
+    }
+
 	rc := C.SCardConnect(c.ctx, C.CString(reader),
-		C.SCARD_SHARE_EXCLUSIVE, C.SCARD_PROTOCOL_T1,
+		mode, C.SCARD_PROTOCOL_T1,
 		&handle, &activeProtocol)
 	if err := scCheck(rc); err != nil {
 		return nil, err

--- a/piv/pcsc_unix.go
+++ b/piv/pcsc_unix.go
@@ -98,10 +98,10 @@ func (c *scContext) Connect(reader string, shared bool) (*scHandle, error) {
 		activeProtocol C.DWORD
 	)
 
-    var mode C.ulong = C.SCARD_SHARE_EXCLUSIVE
-    if shared {
-        mode = C.SCARD_SHARE_SHARED
-    }
+	var mode C.ulong = C.SCARD_SHARE_EXCLUSIVE
+	if shared {
+		mode = C.SCARD_SHARE_SHARED
+	}
 
 	rc := C.SCardConnect(c.ctx, C.CString(reader),
 		mode, C.SCARD_PROTOCOL_T1,

--- a/piv/piv.go
+++ b/piv/piv.go
@@ -51,7 +51,7 @@ var (
 //
 // See: https://ludovicrousseau.blogspot.com/2010/05/what-is-in-pcsc-reader-name.html
 func Cards() ([]string, error) {
-	var c client
+	var c Client
 	return c.Cards()
 }
 
@@ -127,13 +127,13 @@ func (yk *YubiKey) Close() error {
 
 // Open connects to a YubiKey smart card.
 func Open(card string) (*YubiKey, error) {
-	var c client
+	var c Client
 	return c.Open(card)
 }
 
-// client is a smart card client and may be exported in the future to allow
+// Client is a smart card Client and may be exported in the future to allow
 // configuration for the top level Open() and Cards() APIs.
-type client struct {
+type Client struct {
 	// Rand is a cryptographic source of randomness used for card challenges.
 	//
 	// If nil, defaults to crypto.Rand.
@@ -141,7 +141,7 @@ type client struct {
     Shared bool
 }
 
-func (c *client) Cards() ([]string, error) {
+func (c *Client) Cards() ([]string, error) {
 	ctx, err := newSCContext()
 	if err != nil {
 		return nil, fmt.Errorf("connecting to pcsc: %w", err)
@@ -150,7 +150,7 @@ func (c *client) Cards() ([]string, error) {
 	return ctx.ListReaders()
 }
 
-func (c *client) Open(card string) (*YubiKey, error) {
+func (c *Client) Open(card string) (*YubiKey, error) {
 	ctx, err := newSCContext()
 	if err != nil {
 		return nil, fmt.Errorf("connecting to smart card daemon: %w", err)

--- a/piv/piv.go
+++ b/piv/piv.go
@@ -138,7 +138,7 @@ type Client struct {
 	//
 	// If nil, defaults to crypto.Rand.
 	Rand io.Reader
-    Shared bool
+	Shared bool
 }
 
 func (c *Client) Cards() ([]string, error) {

--- a/piv/piv.go
+++ b/piv/piv.go
@@ -137,7 +137,7 @@ type Client struct {
 	// Rand is a cryptographic source of randomness used for card challenges.
 	//
 	// If nil, defaults to crypto.Rand.
-	Rand io.Reader
+	Rand   io.Reader
 	Shared bool
 }
 

--- a/piv/piv.go
+++ b/piv/piv.go
@@ -138,6 +138,7 @@ type client struct {
 	//
 	// If nil, defaults to crypto.Rand.
 	Rand io.Reader
+    Shared bool
 }
 
 func (c *client) Cards() ([]string, error) {
@@ -155,7 +156,7 @@ func (c *client) Open(card string) (*YubiKey, error) {
 		return nil, fmt.Errorf("connecting to smart card daemon: %w", err)
 	}
 
-	h, err := ctx.Connect(card)
+	h, err := ctx.Connect(card, c.Shared)
 	if err != nil {
 		ctx.Close()
 		return nil, fmt.Errorf("connecting to smart card: %w", err)

--- a/piv/piv.go
+++ b/piv/piv.go
@@ -131,7 +131,7 @@ func Open(card string) (*YubiKey, error) {
 	return c.Open(card)
 }
 
-// Client is a smart card Client and may be exported in the future to allow
+// Client is a smart card client and may be exported in the future to allow
 // configuration for the top level Open() and Cards() APIs.
 type Client struct {
 	// Rand is a cryptographic source of randomness used for card challenges.


### PR DESCRIPTION
Add `Shared` field to `Client` struct, which switches access mode to `SCARD_SHARE_SHARED`.

It is required if the Yubikey is used by multiple applications (for example, by VPN client and yubikey-agent). Currently used `SCARD_SHARE_EXCLUSIVE` mode prevents opening yubikey if any other app (e.g, openvpn) is curently using the key.