### PR TITLE
piv: don't attempt to access smartcard if --wipe-yubikey is not provided

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.21.x, 1.22.x]
+        go-version: [1.22.x, 1.23.x]
     name: Linux
     runs-on: ubuntu-latest
     steps:

--- a/v2/piv/pcsc_test.go
+++ b/v2/piv/pcsc_test.go
@@ -21,6 +21,9 @@ import (
 )
 
 func runContextTest(t *testing.T, f func(t *testing.T, c *scContext)) {
+	if !canModifyYubiKey {
+		t.Skip("not running test that accesses yubikey, provide --wipe-yubikey flag")
+	}
 	ctx, err := newSCContext()
 	if err != nil {
 		t.Fatalf("creating context: %v", err)

--- a/v2/piv/piv_test.go
+++ b/v2/piv/piv_test.go
@@ -64,12 +64,20 @@ func testRequiresVersion(t *testing.T, yk *YubiKey, v version) {
 func TestGetVersion(t *testing.T) { runHandleTest(t, testGetVersion) }
 
 func TestCards(t *testing.T) {
+	if !canModifyYubiKey {
+		t.Skip("not running test that accesses yubikey, provide --wipe-yubikey flag")
+	}
+
 	if _, err := Cards(); err != nil {
 		t.Fatalf("listing cards: %v", err)
 	}
 }
 
 func newTestYubiKey(t *testing.T) (*YubiKey, func()) {
+	if !canModifyYubiKey {
+		t.Skip("not running test that accesses yubikey, provide --wipe-yubikey flag")
+	}
+
 	cards, err := Cards()
 	if err != nil {
 		t.Fatalf("listing cards: %v", err)
@@ -77,9 +85,6 @@ func newTestYubiKey(t *testing.T) (*YubiKey, func()) {
 	for _, card := range cards {
 		if !strings.Contains(strings.ToLower(card), "yubikey") {
 			continue
-		}
-		if !canModifyYubiKey {
-			t.Skip("not running test that accesses yubikey, provide --wipe-yubikey flag")
 		}
 		yk, err := Open(card)
 		if err != nil {
@@ -101,6 +106,10 @@ func TestNewYubiKey(t *testing.T) {
 }
 
 func TestMultipleConnections(t *testing.T) {
+	if !canModifyYubiKey {
+		t.Skip("not running test that accesses yubikey, provide --wipe-yubikey flag")
+	}
+
 	cards, err := Cards()
 	if err != nil {
 		t.Fatalf("listing cards: %v", err)


### PR DESCRIPTION
We're seeing CI issues with attempting to access the daemon on GitHub. Since Action's don't exercise most of this package's logic, don't bother even attempting to access the smartcard.