### PR TITLE
Private Ed25519 and RSA keys as public crypt.Signer 

### DIFF
--- a/v2/piv/key.go
+++ b/v2/piv/key.go
@@ -1291,9 +1291,13 @@ type keyEd25519 struct {
 	pp   PINPolicy
 }
 
+type Ed25519Key = keyEd25519
+
 func (k *keyEd25519) Public() crypto.PublicKey {
 	return k.pub
 }
+
+var _ crypto.Signer = (*keyEd25519)(nil)
 
 func (k *keyEd25519) Sign(rand io.Reader, message []byte, opts crypto.SignerOpts) ([]byte, error) {
 	return k.auth.do(k.yk, k.pp, func(tx *scTx) ([]byte, error) {
@@ -1309,9 +1313,13 @@ type keyRSA struct {
 	pp   PINPolicy
 }
 
+type RSAkey = keyRSA
+
 func (k *keyRSA) Public() crypto.PublicKey {
 	return k.pub
 }
+
+var _ crypto.Signer = (*keyRSA)(nil)
 
 func (k *keyRSA) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
 	return k.auth.do(k.yk, k.pp, func(tx *scTx) ([]byte, error) {


### PR DESCRIPTION
As part of another project I wanted crypto.Signers to be provided by the piv-go package. Today only the ECDSA private key i(ECDSAPrivateKey) is public. Thus I am assuming the authors are OK with having other public private keys.

This patch is the minimum code to make this happen by creating an public alias to the current internal struct and ensuring that these internal strut are atually crypto.Signers.

I think this is cleaner than renaming the internal structs. But If you prefer that I can generate such patch.