### PR TITLE
Return ErrNotFound for yubikey error code 0x6a88

### DIFF
--- a/v2/piv/pcsc.go
+++ b/v2/piv/pcsc.go
@@ -95,8 +95,7 @@ func (a *apduErr) Error() string {
 		msg = "not enough memory"
 	case 0x6a86:
 		msg = "incorrect parameter in P1 or P2"
-	case 0x6a88:
-		msg = "referenced data or reference data not found"
+	//0x6a88 is "referenced data or reference data not found" aka ErrNotFound
 	}
 
 	if msg != "" {
@@ -110,6 +109,8 @@ func (a *apduErr) Unwrap() error {
 	st := a.Status()
 	switch {
 	case st == 0x6a82:
+		return ErrNotFound
+	case st == 0x6a88:
 		return ErrNotFound
 	case st == 0x6300:
 		return AuthErr{0}


### PR DESCRIPTION
I noticed that for the newer KeyInfo() method on supported yubikeys if there is no existing data in the requested slot, go-piv returns `smart card error 6a88: referenced data or reference data not found`. However there's an existing ErrNotFound type that's returned by Attest() when there's no data in the slot. I updated the error codes to also return ErrNotFound for `0x6a88` 

To reproduce:
```
package main

import (
        "fmt"
        "strings"

        "github.com/go-piv/piv-go/v2/piv"
)

func main() {
        cards, err := piv.Cards()
        if err != nil {
                fmt.Printf("%v", err)
                return
        }

        // Find a YubiKey and open the reader.
        var yk *piv.YubiKey
        for _, card := range cards {
                if strings.Contains(strings.ToLower(card), "yubikey") {
                        if yk, err = piv.Open(card); err != nil {
                                fmt.Printf("%v", err)
                                return
                        }
                        break
                }
        }
        if yk != nil {
                _, err := yk.KeyInfo(piv.SlotSignature)
                if err != nil {
                        fmt.Println(err)
                }
                _, err = yk.Attest(piv.SlotSignature)
                if errors.Is(err, piv.ErrNotFound) {
                        fmt.Println(err)
                }
        }
}


```

```
$ ykman piv reset
$ ./main
command failed: smart card error 6a88: referenced data or reference data not found
data object or application not found
```