### PR TITLE
Connect with `SCARD_SHARE_SHARED`

### DIFF
--- a/v2/piv/pcsc_unix.go
+++ b/v2/piv/pcsc_unix.go
@@ -98,7 +98,7 @@ func (c *scContext) Connect(reader string) (*scHandle, error) {
 		activeProtocol C.DWORD
 	)
 	rc := C.SCardConnect(c.ctx, C.CString(reader),
-		C.SCARD_SHARE_EXCLUSIVE, C.SCARD_PROTOCOL_T1,
+		C.SCARD_SHARE_SHARED, C.SCARD_PROTOCOL_T1,
 		&handle, &activeProtocol)
 	if err := scCheck(rc); err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes #116

However, there may be other consequences to this change. I don't know what they might be. Hopefully someone with deeper knowledge of the relevant APIs can weigh in.

All I know is that ykpiv also uses `SCARD_SHARE_SHARED`: https://github.com/Yubico/yubico-piv-tool/blob/73db815e8927028c51ba71771a6737efaa238a62/lib/ykpiv.c#L955