### PR TITLE
piv: permit use of shared smartcard connections

### DIFF
--- a/v2/piv/key.go
+++ b/v2/piv/key.go
@@ -616,7 +616,12 @@ func (yk *YubiKey) AttestationCertificate() (*x509.Certificate, error) {
 //
 // If the slot doesn't have a key, the returned error wraps ErrNotFound.
 func (yk *YubiKey) Attest(slot Slot) (*x509.Certificate, error) {
-	cert, err := ykAttest(yk.tx, slot)
+	var cert *x509.Certificate
+	err := yk.tx(func(tx *scTx) error {
+		var err error
+		cert, err = ykAttest(tx, slot)
+		return err
+	})
 	if err == nil {
 		return cert, nil
 	}
@@ -725,7 +730,12 @@ func (yk *YubiKey) KeyInfo(slot Slot) (KeyInfo, error) {
 		param1:      0x00,
 		param2:      byte(slot.Key),
 	}
-	resp, err := yk.tx.Transmit(cmd)
+	var resp []byte
+	err := yk.tx(func(tx *scTx) error {
+		var err error
+		resp, err = tx.Transmit(cmd)
+		return err
+	})
 	if err != nil {
 		return KeyInfo{}, fmt.Errorf("command failed: %w", err)
 	}
@@ -753,7 +763,12 @@ func (yk *YubiKey) Certificate(slot Slot) (*x509.Certificate, error) {
 			byte(slot.Object),
 		},
 	}
-	resp, err := yk.tx.Transmit(cmd)
+	var resp []byte
+	err := yk.tx(func(tx *scTx) error {
+		var err error
+		resp, err = tx.Transmit(cmd)
+		return err
+	})
 	if err != nil {
 		return nil, fmt.Errorf("command failed: %w", err)
 	}
@@ -775,34 +790,39 @@ func (yk *YubiKey) Certificate(slot Slot) (*x509.Certificate, error) {
 
 // FormFactor returns the physical form factor of the YubiKey.
 func (yk *YubiKey) FormFactor() (Formfactor, error) {
-	if err := ykSelectApplication(yk.tx, aidManagement[:]); err != nil {
-		return 0, fmt.Errorf("selecting management applet: %v", err)
-	}
-	defer ykSelectApplication(yk.tx, aidPIV[:])
-	// INS_READ_CONFIG = 0x1D
-	// https://github.com/Yubico/yubikey-manager/blob/9fe76be2cbf5e9a3b5a9a8d78411949a028b3745/yubikit/management.py#L512
-	cmd := apdu{instruction: 0x1D}
-	resp, err := yk.tx.Transmit(cmd)
-	if err != nil {
-		return 0, fmt.Errorf("reading device info: %v", err)
-	}
-	if len(resp) < 1 {
-		return 0, fmt.Errorf("invalid response length")
-	}
-	payload := resp[1:]
-	// TAG_FORM_FACTOR = 0x04
-	// https://github.com/Yubico/yubikey-manager/blob/9fe76be2cbf5e9a3b5a9a8d78411949a028b3745/yubikit/management.py#L211
-	formFactorData, err := findTLVTag(payload, 0x04)
-	if err != nil {
-		if err == errTagNotFound {
-			return 0, nil
+	var formFactor Formfactor = 0
+	err := yk.tx(func(tx *scTx) error {
+		if err := ykSelectApplication(tx, aidManagement[:]); err != nil {
+			return fmt.Errorf("selecting management applet: %v", err)
 		}
-		return 0, fmt.Errorf("parsing response: %v", err)
-	}
-	if len(formFactorData) == 0 {
-		return 0, nil
-	}
-	return Formfactor(formFactorData[0]), nil
+		defer ykSelectApplication(tx, aidPIV[:])
+		// INS_READ_CONFIG = 0x1D
+		// https://github.com/Yubico/yubikey-manager/blob/9fe76be2cbf5e9a3b5a9a8d78411949a028b3745/yubikit/management.py#L512
+		cmd := apdu{instruction: 0x1D}
+		resp, err := tx.Transmit(cmd)
+		if err != nil {
+			return fmt.Errorf("reading device info: %v", err)
+		}
+		if len(resp) < 1 {
+			return fmt.Errorf("invalid response length")
+		}
+		payload := resp[1:]
+		// TAG_FORM_FACTOR = 0x04
+		// https://github.com/Yubico/yubikey-manager/blob/9fe76be2cbf5e9a3b5a9a8d78411949a028b3745/yubikit/management.py#L211
+		formFactorData, err := findTLVTag(payload, 0x04)
+		if err != nil {
+			if err == errTagNotFound {
+				return nil
+			}
+			return fmt.Errorf("parsing response: %v", err)
+		}
+		if len(formFactorData) == 0 {
+			return nil
+		}
+		formFactor = Formfactor(formFactorData[0])
+		return nil
+	})
+	return formFactor, err
 }
 
 // findTLVTag searches through TLV (Tag-Length-Value) encoded data for a
@@ -912,10 +932,12 @@ func marshalASN1(tag byte, data []byte) []byte {
 // certificate isn't required to use the associated key for signing or
 // decryption.
 func (yk *YubiKey) SetCertificate(key []byte, slot Slot, cert *x509.Certificate) error {
-	if err := ykAuthenticate(yk.tx, key, yk.rand, yk.version); err != nil {
-		return fmt.Errorf("authenticating with management key: %w", err)
-	}
-	return ykStoreCertificate(yk.tx, slot, cert)
+	return yk.tx(func(tx *scTx) error {
+		if err := ykAuthenticate(tx, key, yk.rand, yk.version); err != nil {
+			return fmt.Errorf("authenticating with management key: %w", err)
+		}
+		return ykStoreCertificate(tx, slot, cert)
+	})
 }
 
 func ykStoreCertificate(tx *scTx, slot Slot, cert *x509.Certificate) error {
@@ -966,10 +988,16 @@ type Key struct {
 // GenerateKey generates an asymmetric key on the card, returning the key's
 // public key.
 func (yk *YubiKey) GenerateKey(key []byte, slot Slot, opts Key) (crypto.PublicKey, error) {
-	if err := ykAuthenticate(yk.tx, key, yk.rand, yk.version); err != nil {
-		return nil, fmt.Errorf("authenticating with management key: %w", err)
-	}
-	return ykGenerateKey(yk.tx, slot, opts)
+	var pub crypto.PublicKey
+	err := yk.tx(func(tx *scTx) error {
+		if err := ykAuthenticate(tx, key, yk.rand, yk.version); err != nil {
+			return fmt.Errorf("authenticating with management key: %w", err)
+		}
+		var err error
+		pub, err = ykGenerateKey(tx, slot, opts)
+		return err
+	})
+	return pub, err
 }
 
 func ykGenerateKey(tx *scTx, slot Slot, o Key) (crypto.PublicKey, error) {
@@ -1053,8 +1081,12 @@ type KeyAuth struct {
 	// If provided, PINPrompt is ignored.
 	PIN string
 	// PINPrompt can be used to interactively request the PIN from the user. The
-	// method is only called when needed. For example, if a key specifies
-	// PINPolicyOnce, PINPrompt will only be called once per YubiKey struct.
+	// method is only called when needed for exclusive connections. If a key
+	// specifies PINPolicyOnce, PINPrompt will only be called once per YubiKey
+	// struct.
+	//
+	// Clients using a shared connection will call the PIN prompt on every
+	// operation, regardless of PIN policy.
 	PINPrompt func() (pin string, err error)
 
 	// PINPolicy can be used to specify the PIN caching strategy for the slot. If
@@ -1065,7 +1097,7 @@ type KeyAuth struct {
 	PINPolicy PINPolicy
 }
 
-func (k KeyAuth) authTx(yk *YubiKey, pp PINPolicy) error {
+func (k KeyAuth) authTx(tx *scTx, pp PINPolicy) error {
 	// PINPolicyNever shouldn't require a PIN.
 	if pp == PINPolicyNever {
 		return nil
@@ -1079,7 +1111,7 @@ func (k KeyAuth) authTx(yk *YubiKey, pp PINPolicy) error {
 	// PINPolicyAlways should always prompt a PIN even if the key says that
 	// login isn't needed.
 	// https://github.com/go-piv/piv-go/issues/49
-	if pp != PINPolicyAlways && !ykLoginNeeded(yk.tx) {
+	if pp != PINPolicyAlways && !ykLoginNeeded(tx) {
 		return nil
 	}
 
@@ -1094,41 +1126,47 @@ func (k KeyAuth) authTx(yk *YubiKey, pp PINPolicy) error {
 	if pin == "" {
 		return fmt.Errorf("pin required but wasn't provided")
 	}
-	return ykLogin(yk.tx, pin)
+	return ykLogin(tx, pin)
 }
 
 func (k KeyAuth) do(yk *YubiKey, pp PINPolicy, f func(tx *scTx) ([]byte, error)) ([]byte, error) {
 	const swSecurityStatusNotSatisfied = 0x6982
-
-	if pp == PINPolicyMatchAlways {
-		if err := yk.VerifyBiometrics(); err != nil {
-			return nil, err
-		}
-		return f(yk.tx)
-	}
-
-	if pp == PINPolicyMatchOnce {
-		if err := k.authTx(yk, pp); err != nil {
-			return nil, err
-		}
-		resp, err := f(yk.tx)
-		if err == nil {
-			return resp, nil
-		}
-		var apdu *apduErr
-		if errors.As(err, &apdu) && apdu.Status() == swSecurityStatusNotSatisfied {
-			if err := yk.VerifyBiometrics(); err != nil {
-				return nil, err
+	var b []byte
+	err := yk.tx(func(tx *scTx) error {
+		var err error
+		if pp == PINPolicyMatchAlways {
+			if err := ykVerifyUV(tx); err != nil {
+				return err
 			}
-			return f(yk.tx)
+			b, err = f(tx)
+			return err
 		}
-		return nil, err
-	}
 
-	if err := k.authTx(yk, pp); err != nil {
-		return nil, err
-	}
-	return f(yk.tx)
+		if pp == PINPolicyMatchOnce {
+			if err := k.authTx(tx, pp); err != nil {
+				return err
+			}
+			b, err = f(tx)
+			if err == nil {
+				return nil
+			}
+			var apdu *apduErr
+			if errors.As(err, &apdu) && apdu.Status() == swSecurityStatusNotSatisfied {
+				if err := ykVerifyUV(tx); err != nil {
+					return err
+				}
+				b, err = f(tx)
+			}
+			return err
+		}
+
+		if err := k.authTx(tx, pp); err != nil {
+			return err
+		}
+		b, err = f(tx)
+		return err
+	})
+	return b, err
 }
 
 func pinPolicy(yk *YubiKey, slot Slot) (PINPolicy, error) {
@@ -1307,11 +1345,13 @@ func (yk *YubiKey) SetPrivateKeyInsecure(key []byte, slot Slot, private crypto.P
 		tags = append(tags, param...)
 	}
 
-	if err := ykAuthenticate(yk.tx, key, yk.rand, yk.version); err != nil {
-		return fmt.Errorf("authenticating with management key: %w", err)
-	}
+	return yk.tx(func(tx *scTx) error {
+		if err := ykAuthenticate(tx, key, yk.rand, yk.version); err != nil {
+			return fmt.Errorf("authenticating with management key: %w", err)
+		}
 
-	return ykImportKey(yk.tx, tags, slot, policy)
+		return ykImportKey(tx, tags, slot, policy)
+	})
 }
 
 func ykImportKey(tx *scTx, tags []byte, slot Slot, o Key) error {

--- a/v2/piv/pcsc_test.go
+++ b/v2/piv/pcsc_test.go
@@ -66,7 +66,7 @@ func runHandleTest(t *testing.T, f func(t *testing.T, h *scHandle)) {
 		if reader == "" {
 			t.Skip("could not find yubikey, skipping testing")
 		}
-		h, err := c.Connect(reader)
+		h, err := c.Connect(reader, false)
 		if err != nil {
 			t.Fatalf("connecting to %s: %v", reader, err)
 		}

--- a/v2/piv/pcsc_unix.go
+++ b/v2/piv/pcsc_unix.go
@@ -92,13 +92,17 @@ type scHandle struct {
 	h C.SCARDHANDLE
 }
 
-func (c *scContext) Connect(reader string) (*scHandle, error) {
+func (c *scContext) Connect(reader string, shared bool) (*scHandle, error) {
 	var (
 		handle         C.SCARDHANDLE
 		activeProtocol C.DWORD
 	)
+	var mode C.DWORD = C.SCARD_SHARE_EXCLUSIVE
+	if shared {
+		mode = C.SCARD_SHARE_SHARED
+	}
 	rc := C.SCardConnect(c.ctx, C.CString(reader),
-		C.SCARD_SHARE_EXCLUSIVE, C.SCARD_PROTOCOL_T1,
+		mode, C.SCARD_PROTOCOL_T1,
 		&handle, &activeProtocol)
 	if err := scCheck(rc); err != nil {
 		return nil, err

--- a/v2/piv/pcsc_windows.go
+++ b/v2/piv/pcsc_windows.go
@@ -35,6 +35,7 @@ var (
 const (
 	scardScopeSystem      = 2
 	scardShareExclusive   = 1
+	scardShareShared      = 2
 	scardLeaveCard        = 0
 	scardProtocolT1       = 2
 	scardPCIT1            = 0
@@ -122,7 +123,7 @@ func (c *scContext) ListReaders() ([]string, error) {
 	return readers, nil
 }
 
-func (c *scContext) Connect(reader string) (*scHandle, error) {
+func (c *scContext) Connect(reader string, shared bool) (*scHandle, error) {
 	var (
 		handle         syscall.Handle
 		activeProtocol uint16
@@ -131,10 +132,15 @@ func (c *scContext) Connect(reader string) (*scHandle, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid reader string: %v", err)
 	}
+
+	mode := uintptr(scardShareExclusive)
+	if shared {
+		mode = scardShareShared
+	}
 	r0, _, _ := procSCardConnectW.Call(
 		uintptr(c.ctx),
 		uintptr(unsafe.Pointer(readerPtr)),
-		scardShareExclusive,
+		mode,
 		scardProtocolT1,
 		uintptr(unsafe.Pointer(&handle)),
 		uintptr(activeProtocol),

--- a/v2/piv/piv.go
+++ b/v2/piv/piv.go
@@ -43,6 +43,8 @@ var (
 		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
 		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
 	}
+
+	defaultClient = &Client{}
 )
 
 // Cards lists all smart cards available via PC/SC interface. Card names are
@@ -53,8 +55,7 @@ var (
 //
 // See: https://ludovicrousseau.blogspot.com/2010/05/what-is-in-pcsc-reader-name.html
 func Cards() ([]string, error) {
-	var c client
-	return c.Cards()
+	return defaultClient.Cards()
 }
 
 const (
@@ -111,7 +112,9 @@ const (
 type YubiKey struct {
 	ctx *scContext
 	h   *scHandle
-	tx  *scTx
+
+	// May be nil, use tx() to access.
+	exclusiveTx *scTx
 
 	rand io.Reader
 
@@ -121,35 +124,76 @@ type YubiKey struct {
 	// YubiKey's version or PIV version? A NEO reports v1.0.4. Figure this out
 	// before exposing an API.
 	version *version
+}
 
+func (yk *YubiKey) tx(fn func(tx *scTx) error) (err error) {
+	tx := yk.exclusiveTx
+	if tx == nil {
+		tx, err = yk.h.Begin()
+		if err != nil {
+			return fmt.Errorf("beginning transaction: %v", err)
+		}
+		defer func() {
+			terr := tx.Close()
+			if terr != nil && err == nil {
+				err = fmt.Errorf("closing trasnaction: %v", terr)
+			}
+		}()
+
+		if err := ykSelectApplication(tx, aidPIV[:]); err != nil {
+			return fmt.Errorf("selecting piv applet: %w", err)
+		}
+	}
+	return fn(tx)
 }
 
 // Close releases the connection to the smart card.
 func (yk *YubiKey) Close() error {
-	err1 := yk.h.Close()
-	err2 := yk.ctx.Close()
-	if err1 == nil {
-		return err2
+	var err error
+	if yk.h != nil {
+		err = yk.h.Close()
 	}
-	return err1
+	if yk.ctx != nil {
+		cerr := yk.ctx.Close()
+		if err == nil {
+			err = cerr
+		}
+	}
+	return err
 }
 
 // Open connects to a YubiKey smart card.
 func Open(card string) (*YubiKey, error) {
-	var c client
-	return c.Open(card)
+	return defaultClient.Open(card)
 }
 
-// client is a smart card client and may be exported in the future to allow
-// configuration for the top level Open() and Cards() APIs.
-type client struct {
-	// Rand is a cryptographic source of randomness used for card challenges.
+// Client can be used to configure the behavior of the smartcard connection.
+type Client struct {
+	// Rand is a cryptographic source of randomness used for card challenges,
+	// and other operations.
 	//
 	// If nil, defaults to crypto.Rand.
 	Rand io.Reader
+
+	// Shared causes the client to use a non-exclusive connection to the
+	// smartcard, allowing multiple concurrent users of the PCSC daemon.
+	// Note that a single client using an exclusive connection will block
+	// transactions for all other clients. For example, common GPG agents
+	// use exclusive connections that don't work with this option.
+	//
+	// Enabling this option breaks PINPolicyOnce, requiring a PIN on every
+	// operation.
+	Shared bool
 }
 
-func (c *client) Cards() ([]string, error) {
+// Cards lists all smart cards available via PC/SC interface. Card names are
+// strings describing the key, such as "Yubico Yubikey NEO OTP+U2F+CCID 00 00".
+//
+// Card names depend on the operating system and what port a card is plugged
+// into. To uniquely identify a card, use its serial number.
+//
+// See: https://ludovicrousseau.blogspot.com/2010/05/what-is-in-pcsc-reader-name.html
+func (c *Client) Cards() ([]string, error) {
 	ctx, err := newSCContext()
 	if err != nil {
 		return nil, fmt.Errorf("connecting to pcsc: %w", err)
@@ -158,37 +202,51 @@ func (c *client) Cards() ([]string, error) {
 	return ctx.ListReaders()
 }
 
-func (c *client) Open(card string) (*YubiKey, error) {
+// Open connects to a YubiKey smart card.
+func (c *Client) Open(card string) (*YubiKey, error) {
 	ctx, err := newSCContext()
 	if err != nil {
 		return nil, fmt.Errorf("connecting to smart card daemon: %w", err)
 	}
 
-	h, err := ctx.Connect(card)
-	if err != nil {
-		ctx.Close()
-		return nil, fmt.Errorf("connecting to smart card: %w", err)
-	}
-	tx, err := h.Begin()
-	if err != nil {
-		return nil, fmt.Errorf("beginning smart card transaction: %w", err)
-	}
-	if err := ykSelectApplication(tx, aidPIV[:]); err != nil {
-		tx.Close()
-		return nil, fmt.Errorf("selecting piv applet: %w", err)
-	}
+	yk := &YubiKey{ctx: ctx}
 
-	yk := &YubiKey{ctx: ctx, h: h, tx: tx}
-	v, err := ykVersion(yk.tx)
-	if err != nil {
-		yk.Close()
-		return nil, fmt.Errorf("getting yubikey version: %w", err)
-	}
-	yk.version = v
 	if c.Rand != nil {
 		yk.rand = c.Rand
 	} else {
 		yk.rand = rand.Reader
+	}
+
+	h, err := ctx.Connect(card, c.Shared)
+	if err != nil {
+		yk.Close()
+		return nil, fmt.Errorf("connecting to smart card: %w", err)
+	}
+	yk.h = h
+
+	if !c.Shared {
+		tx, err := h.Begin()
+		if err != nil {
+			return nil, fmt.Errorf("beginning smart card transaction: %w", err)
+		}
+		yk.exclusiveTx = tx
+	}
+
+	err = yk.tx(func(tx *scTx) error {
+		if err := ykSelectApplication(tx, aidPIV[:]); err != nil {
+			return fmt.Errorf("selecting piv applet: %w", err)
+		}
+
+		v, err := ykVersion(tx)
+		if err != nil {
+			return fmt.Errorf("getting yubikey version: %w", err)
+		}
+		yk.version = v
+		return nil
+	})
+	if err != nil {
+		yk.Close()
+		return nil, err
 	}
 	return yk, nil
 }
@@ -208,7 +266,13 @@ func (yk *YubiKey) Version() Version {
 
 // Serial returns the YubiKey's serial number.
 func (yk *YubiKey) Serial() (uint32, error) {
-	return ykSerial(yk.tx, yk.version)
+	var n uint32
+	err := yk.tx(func(tx *scTx) error {
+		var err error
+		n, err = ykSerial(tx, yk.version)
+		return err
+	})
+	return n, err
 }
 
 func encodePIN(pin string) ([]byte, error) {
@@ -241,7 +305,9 @@ func encodePIN(pin string) ([]byte, error) {
 //
 // Use DefaultPIN if the PIN hasn't been set.
 func (yk *YubiKey) VerifyPIN(pin string) error {
-	return ykLogin(yk.tx, pin)
+	return yk.tx(func(tx *scTx) error {
+		return ykLogin(tx, pin)
+	})
 }
 
 // VerifyBiometrics performs biometric user verification (YubiKey Bio) for PIV.
@@ -249,7 +315,9 @@ func (yk *YubiKey) VerifyPIN(pin string) error {
 // decrypting. When using PINPolicyMatchAlways, call this before every signing
 // or decrypting operation.
 func (yk *YubiKey) VerifyBiometrics() error {
-	return ykVerifyUV(yk.tx)
+	return yk.tx(func(tx *scTx) error {
+		return ykVerifyUV(tx)
+	})
 }
 
 func ykLogin(tx *scTx, pin string) error {
@@ -287,7 +355,13 @@ func ykLoginNeeded(tx *scTx) bool {
 
 // Retries returns the number of attempts remaining to enter the correct PIN.
 func (yk *YubiKey) Retries() (int, error) {
-	return ykPINRetries(yk.tx)
+	var n int
+	err := yk.tx(func(tx *scTx) error {
+		var err error
+		n, err = ykPINRetries(tx)
+		return err
+	})
+	return n, err
 }
 
 func ykPINRetries(tx *scTx) (int, error) {
@@ -307,7 +381,9 @@ func ykPINRetries(tx *scTx) (int, error) {
 // and resetting the PIN, PUK, and Management Key to their default values. This
 // does NOT affect data on other applets, such as GPG or U2F.
 func (yk *YubiKey) Reset() error {
-	return ykReset(yk.tx, yk.rand)
+	return yk.tx(func(tx *scTx) error {
+		return ykReset(tx, yk.rand)
+	})
 }
 
 func ykReset(tx *scTx, r io.Reader) error {
@@ -375,8 +451,8 @@ type version struct {
 // certificates to slots.
 //
 // Use DefaultManagementKey if the management key hasn't been set.
-func (yk *YubiKey) authManagementKey(key []byte) error {
-	return ykAuthenticate(yk.tx, key, yk.rand, yk.version)
+func (yk *YubiKey) authManagementKey(tx *scTx, key []byte) error {
+	return ykAuthenticate(tx, key, yk.rand, yk.version)
 }
 
 var (
@@ -541,13 +617,12 @@ func ykAuthenticate(tx *scTx, key []byte, rand io.Reader, version *version) erro
 //		// ...
 //	}
 func (yk *YubiKey) SetManagementKey(oldKey, newKey []byte) error {
-	if err := ykAuthenticate(yk.tx, oldKey, yk.rand, yk.version); err != nil {
-		return fmt.Errorf("authenticating with old key: %w", err)
-	}
-	if err := ykSetManagementKey(yk.tx, newKey, false, yk.version); err != nil {
-		return err
-	}
-	return nil
+	return yk.tx(func(tx *scTx) error {
+		if err := ykAuthenticate(tx, oldKey, yk.rand, yk.version); err != nil {
+			return fmt.Errorf("authenticating with old key: %w", err)
+		}
+		return ykSetManagementKey(tx, newKey, false, yk.version)
+	})
 }
 
 // ykSetManagementKey updates the management key to a new key. This requires
@@ -605,7 +680,9 @@ func ykSetManagementKey(tx *scTx, key []byte, touch bool, version *version) erro
 //		// ...
 //	}
 func (yk *YubiKey) SetPIN(oldPIN, newPIN string) error {
-	return ykChangePIN(yk.tx, oldPIN, newPIN)
+	return yk.tx(func(tx *scTx) error {
+		return ykChangePIN(tx, oldPIN, newPIN)
+	})
 }
 
 func ykChangePIN(tx *scTx, oldPIN, newPIN string) error {
@@ -628,7 +705,9 @@ func ykChangePIN(tx *scTx, oldPIN, newPIN string) error {
 
 // Unblock unblocks the PIN, setting it to a new value.
 func (yk *YubiKey) Unblock(puk, newPIN string) error {
-	return ykUnblockPIN(yk.tx, puk, newPIN)
+	return yk.tx(func(tx *scTx) error {
+		return ykUnblockPIN(tx, puk, newPIN)
+	})
 }
 
 func ykUnblockPIN(tx *scTx, puk, newPIN string) error {
@@ -665,7 +744,9 @@ func ykUnblockPIN(tx *scTx, puk, newPIN string) error {
 //		// ...
 //	}
 func (yk *YubiKey) SetPUK(oldPUK, newPUK string) error {
-	return ykChangePUK(yk.tx, oldPUK, newPUK)
+	return yk.tx(func(tx *scTx) error {
+		return ykChangePUK(tx, oldPUK, newPUK)
+	})
 }
 
 func ykChangePUK(tx *scTx, oldPUK, newPUK string) error {
@@ -700,7 +781,9 @@ func ykChangePUK(tx *scTx, oldPUK, newPUK string) error {
 //		// ...
 //	}
 func (yk *YubiKey) SetRetries(managementKey []byte, pin string, pinRetries int, pukRetries int) error {
-	return ykSetRetries(yk.tx, managementKey, pin, pinRetries, pukRetries, yk.rand, yk.version)
+	return yk.tx(func(tx *scTx) error {
+		return ykSetRetries(tx, managementKey, pin, pinRetries, pukRetries, yk.rand, yk.version)
+	})
 }
 
 func ykSetRetries(tx *scTx, managementKey []byte, pin string, pinRetries int, pukRetries int, rand io.Reader, version *version) error {
@@ -777,21 +860,28 @@ func ykSerial(tx *scTx, v *version) (uint32, error) {
 // Metadata returns protected data stored on the card. This can be used to
 // retrieve PIN protected management keys.
 func (yk *YubiKey) Metadata(pin string) (*Metadata, error) {
-	m, err := ykGetProtectedMetadata(yk.tx, pin)
-	if err != nil {
-		if errors.Is(err, ErrNotFound) {
-			return &Metadata{}, nil
+	var m *Metadata
+	err := yk.tx(func(tx *scTx) error {
+		var err error
+		m, err = ykGetProtectedMetadata(tx, pin)
+		if err != nil {
+			if errors.Is(err, ErrNotFound) {
+				m = &Metadata{}
+				err = nil
+			}
 		}
-		return nil, err
-	}
-	return m, nil
+		return err
+	})
+	return m, err
 }
 
 // SetMetadata sets PIN protected metadata on the key. This is primarily to
 // store the management key on the smart card instead of managing the PIN and
 // management key seperately.
 func (yk *YubiKey) SetMetadata(key []byte, m *Metadata) error {
-	return ykSetProtectedMetadata(yk.tx, key, m, yk.rand, yk.version)
+	return yk.tx(func(tx *scTx) error {
+		return ykSetProtectedMetadata(tx, key, m, yk.rand, yk.version)
+	})
 }
 
 // Metadata holds protected metadata. This is primarily used by YubiKey manager

--- a/v2/piv/piv_test.go
+++ b/v2/piv/piv_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"math/bits"
 	"strings"
@@ -73,12 +74,31 @@ func TestCards(t *testing.T) {
 	}
 }
 
+func runTest(t *testing.T, fn func(*testing.T, *YubiKey)) {
+	t.Run("Exclusive", func(t *testing.T) {
+		yk, close := newTestYubiKey(t)
+		fn(t, yk)
+		close()
+	})
+	t.Run("Shared", func(t *testing.T) {
+		c := &Client{Shared: true}
+		yk, close := newTestYubiKeyClient(t, c)
+		fn(t, yk)
+		close()
+	})
+}
+
 func newTestYubiKey(t *testing.T) (*YubiKey, func()) {
+	var c Client
+	return newTestYubiKeyClient(t, &c)
+}
+
+func newTestYubiKeyClient(t *testing.T, c *Client) (*YubiKey, func()) {
 	if !canModifyYubiKey {
 		t.Skip("not running test that accesses yubikey, provide --wipe-yubikey flag")
 	}
 
-	cards, err := Cards()
+	cards, err := c.Cards()
 	if err != nil {
 		t.Fatalf("listing cards: %v", err)
 	}
@@ -86,7 +106,7 @@ func newTestYubiKey(t *testing.T) (*YubiKey, func()) {
 		if !strings.Contains(strings.ToLower(card), "yubikey") {
 			continue
 		}
-		yk, err := Open(card)
+		yk, err := c.Open(card)
 		if err != nil {
 			t.Fatalf("getting new yubikey: %v", err)
 		}
@@ -148,29 +168,33 @@ func TestMultipleConnections(t *testing.T) {
 }
 
 func TestYubiKeySerial(t *testing.T) {
-	yk, close := newTestYubiKey(t)
-	defer close()
-
-	if _, err := yk.Serial(); err != nil {
-		t.Fatalf("getting serial number: %v", err)
-	}
+	runTest(t, func(t *testing.T, yk *YubiKey) {
+		if _, err := yk.Serial(); err != nil {
+			t.Fatalf("getting serial number: %v", err)
+		}
+	})
 }
 
 func TestYubiKeyLoginNeeded(t *testing.T) {
-	yk, close := newTestYubiKey(t)
-	defer close()
+	runTest(t, func(t *testing.T, yk *YubiKey) {
+		// TODO testRequiresVersion(t, yk, version43) ?
 
-	testRequiresVersion(t, yk, version43)
-
-	if !ykLoginNeeded(yk.tx) {
-		t.Errorf("expected login needed")
-	}
-	if err := ykLogin(yk.tx, DefaultPIN); err != nil {
-		t.Fatalf("login: %v", err)
-	}
-	if ykLoginNeeded(yk.tx) {
-		t.Errorf("expected no login needed")
-	}
+		err := yk.tx(func(tx *scTx) error {
+			if !ykLoginNeeded(tx) {
+				t.Errorf("expected login needed")
+			}
+			if err := ykLogin(tx, DefaultPIN); err != nil {
+				t.Fatalf("login: %v", err)
+			}
+			if ykLoginNeeded(tx) {
+				t.Errorf("expected no login needed")
+			}
+			return nil
+		})
+		if err != nil {
+			t.Errorf("transaction failed: %v", err)
+		}
+	})
 }
 
 func TestYubiKeyPINRetries(t *testing.T) {
@@ -186,210 +210,214 @@ func TestYubiKeyPINRetries(t *testing.T) {
 		}
 	}()
 
-	yk, close := newTestYubiKey(t)
-	defer close()
-
-	retries, err := yk.Retries()
-	if err != nil {
-		t.Fatalf("getting retries: %v", err)
-	}
-	if retries < 0 || retries > 15 {
-		t.Fatalf("invalid number of retries: %d", retries)
-	}
+	runTest(t, func(t *testing.T, yk *YubiKey) {
+		retries, err := yk.Retries()
+		if err != nil {
+			t.Fatalf("getting retries: %v", err)
+		}
+		if retries < 0 || retries > 15 {
+			t.Fatalf("invalid number of retries: %d", retries)
+		}
+	})
 }
 
 func TestYubiKeyReset(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode.")
-	}
-	yk, close := newTestYubiKey(t)
-	defer close()
-	if err := yk.Reset(); err != nil {
-		t.Fatalf("resetting yubikey: %v", err)
-	}
-	if err := yk.VerifyPIN(DefaultPIN); err != nil {
-		t.Fatalf("login: %v", err)
-	}
-}
-
-func TestYubiKeyLogin(t *testing.T) {
-	yk, close := newTestYubiKey(t)
-	defer close()
-
-	if err := yk.VerifyPIN(DefaultPIN); err != nil {
-		t.Fatalf("login: %v", err)
-	}
-}
-
-func TestYubiKeyAuthenticate(t *testing.T) {
-	yk, close := newTestYubiKey(t)
-	defer close()
-
-	if err := yk.authManagementKey(DefaultManagementKey); err != nil {
-		t.Errorf("authenticating: %v", err)
-	}
-}
-
-func TestYubiKeySetManagementKey(t *testing.T) {
-	yk, close := newTestYubiKey(t)
-	defer close()
-
-	var mgmtKey [24]byte
-	if _, err := io.ReadFull(rand.Reader, mgmtKey[:]); err != nil {
-		t.Fatalf("generating management key: %v", err)
-	}
-
-	if err := yk.SetManagementKey(DefaultManagementKey, mgmtKey[:]); err != nil {
-		t.Fatalf("setting management key: %v", err)
-	}
-	if err := yk.authManagementKey(mgmtKey[:]); err != nil {
-		t.Errorf("authenticating with new management key: %v", err)
-	}
-	if err := yk.SetManagementKey(mgmtKey[:], DefaultManagementKey); err != nil {
-		t.Fatalf("resetting management key: %v", err)
-	}
-}
-
-func TestYubiKeyUnblockPIN(t *testing.T) {
-	yk, close := newTestYubiKey(t)
-	defer close()
-
-	badPIN := "0"
-	for {
-		err := ykLogin(yk.tx, badPIN)
-		if err == nil {
-			t.Fatalf("login with bad pin succeeded")
+	runTest(t, func(t *testing.T, yk *YubiKey) {
+		if testing.Short() {
+			t.Skip("skipping test in short mode.")
 		}
-		var e AuthErr
-		if !errors.As(err, &e) {
-			t.Fatalf("error returned was not a wrong pin error: %v", err)
-		}
-		if e.Retries == 0 {
-			break
-		}
-	}
-
-	if err := yk.Unblock(DefaultPUK, DefaultPIN); err != nil {
-		t.Fatalf("unblocking pin: %v", err)
-	}
-	if err := ykLogin(yk.tx, DefaultPIN); err != nil {
-		t.Errorf("failed to login with pin after unblock: %v", err)
-	}
-}
-
-func TestYubiKeyChangePIN(t *testing.T) {
-	yk, close := newTestYubiKey(t)
-	defer close()
-
-	newPIN := "654321"
-	if err := yk.SetPIN(newPIN, newPIN); err == nil {
-		t.Errorf("successfully changed pin with invalid pin, expected error")
-	}
-	if err := yk.SetPIN(DefaultPIN, newPIN); err != nil {
-		t.Fatalf("changing pin: %v", err)
-	}
-	if err := yk.SetPIN(newPIN, DefaultPIN); err != nil {
-		t.Fatalf("resetting pin: %v", err)
-	}
-}
-
-func TestYubiKeyChangePUK(t *testing.T) {
-	yk, close := newTestYubiKey(t)
-	defer close()
-
-	newPUK := "87654321"
-	if err := yk.SetPUK(newPUK, newPUK); err == nil {
-		t.Errorf("successfully changed puk with invalid puk, expected error")
-	}
-	if err := yk.SetPUK(DefaultPUK, newPUK); err != nil {
-		t.Fatalf("changing puk: %v", err)
-	}
-	if err := yk.SetPUK(newPUK, DefaultPUK); err != nil {
-		t.Fatalf("resetting puk: %v", err)
-	}
-}
-
-func TestYubiKeyChangeRetries(t *testing.T) {
-	yk, close := newTestYubiKey(t)
-	defer close()
-
-	if err := yk.SetRetries(DefaultManagementKey, DefaultPIN, 3, 0); err == nil {
-		t.Errorf("successfully set retries to zeros, expected error")
-	}
-	if err := yk.SetRetries(DefaultManagementKey, DefaultPIN, 256, 3); err == nil {
-		t.Errorf("successfully set retries greater than 255, expected error")
-	}
-	if err := yk.SetRetries(DefaultManagementKey, DefaultPIN, 5, 3); err != nil {
-		t.Fatalf("setting pin/puk retries: %v", err)
-	}
-}
-
-func TestChangeManagementKey(t *testing.T) {
-	yk, close := newTestYubiKey(t)
-	defer close()
-
-	var newKey [24]byte
-	if _, err := io.ReadFull(rand.Reader, newKey[:]); err != nil {
-		t.Fatalf("generating new management key: %v", err)
-	}
-	// Apply odd-parity
-	for i, b := range newKey {
-		if bits.OnesCount8(uint8(b))%2 == 0 {
-			newKey[i] = b ^ 1 // flip least significant bit
-		}
-	}
-	if err := yk.SetManagementKey(newKey[:], newKey[:]); err == nil {
-		t.Errorf("successfully changed management key with invalid key, expected error")
-	}
-	if err := yk.SetManagementKey(DefaultManagementKey, newKey[:]); err != nil {
-		t.Fatalf("changing management key: %v", err)
-	}
-	if err := yk.SetManagementKey(newKey[:], DefaultManagementKey); err != nil {
-		t.Fatalf("resetting management key: %v", err)
-	}
-}
-
-func TestMetadata(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode.")
-	}
-	func() {
-		yk, close := newTestYubiKey(t)
-		defer close()
 		if err := yk.Reset(); err != nil {
 			t.Fatalf("resetting yubikey: %v", err)
 		}
-	}()
+		if err := yk.VerifyPIN(DefaultPIN); err != nil {
+			t.Fatalf("login: %v", err)
+		}
+	})
+}
 
-	yk, close := newTestYubiKey(t)
-	defer close()
+func TestYubiKeyLogin(t *testing.T) {
+	runTest(t, func(t *testing.T, yk *YubiKey) {
+		if err := yk.VerifyPIN(DefaultPIN); err != nil {
+			t.Fatalf("login: %v", err)
+		}
+	})
+}
 
-	if m, err := yk.Metadata(DefaultPIN); err != nil {
-		t.Errorf("getting metadata: %v", err)
-	} else if m.ManagementKey != nil {
-		t.Errorf("expected no management key set")
-	}
+func TestYubiKeyAuthenticate(t *testing.T) {
+	runTest(t, func(t *testing.T, yk *YubiKey) {
+		err := yk.tx(func(tx *scTx) error {
+			return yk.authManagementKey(tx, DefaultManagementKey)
+		})
+		if err != nil {
+			t.Errorf("authenticating: %v", err)
+		}
+	})
+}
 
-	wantKey := []byte{
-		0x09, 0xd9, 0x87, 0x81, 0xfb, 0xdc, 0xc9, 0xb6,
-		0x91, 0xa2, 0x05, 0x80, 0x6e, 0xc0, 0xba, 0x84,
-		0x31, 0xac, 0x0d, 0x9f, 0x59, 0xa5, 0x00, 0xad,
-	}
-	m := &Metadata{
-		ManagementKey: &wantKey,
-	}
-	if err := yk.SetMetadata(DefaultManagementKey, m); err != nil {
-		t.Fatalf("setting metadata: %v", err)
-	}
-	got, err := yk.Metadata(DefaultPIN)
-	if err != nil {
-		t.Fatalf("getting metadata: %v", err)
-	}
-	if got.ManagementKey == nil {
-		t.Errorf("no management key")
-	} else if !bytes.Equal(*got.ManagementKey, wantKey) {
-		t.Errorf("wanted management key=0x%x, got=0x%x", wantKey, got.ManagementKey)
-	}
+func TestYubiKeySetManagementKey(t *testing.T) {
+	runTest(t, func(t *testing.T, yk *YubiKey) {
+		var mgmtKey [24]byte
+		if _, err := io.ReadFull(rand.Reader, mgmtKey[:]); err != nil {
+			t.Fatalf("generating management key: %v", err)
+		}
+
+		if err := yk.SetManagementKey(DefaultManagementKey, mgmtKey[:]); err != nil {
+			t.Fatalf("setting management key: %v", err)
+		}
+		err := yk.tx(func(tx *scTx) error {
+			return yk.authManagementKey(tx, mgmtKey[:])
+		})
+		if err != nil {
+			t.Errorf("authenticating with new management key: %v", err)
+		}
+		if err := yk.SetManagementKey(mgmtKey[:], DefaultManagementKey); err != nil {
+			t.Fatalf("resetting management key: %v", err)
+		}
+	})
+}
+
+func TestYubiKeyUnblockPIN(t *testing.T) {
+	runTest(t, func(t *testing.T, yk *YubiKey) {
+		err := yk.tx(func(tx *scTx) error {
+			badPIN := "0"
+			for {
+				err := ykLogin(tx, badPIN)
+				if err == nil {
+					return fmt.Errorf("login with bad pin succeeded")
+				}
+				var e AuthErr
+				if !errors.As(err, &e) {
+					return fmt.Errorf("error returned was not a wrong pin error: %v", err)
+				}
+				if e.Retries == 0 {
+					return nil
+				}
+			}
+		})
+		if err != nil {
+			t.Fatalf("blocking pin: %v", err)
+		}
+
+		if err := yk.Unblock(DefaultPUK, DefaultPIN); err != nil {
+			t.Fatalf("unblocking pin: %v", err)
+		}
+		if err := yk.tx(func(tx *scTx) error {
+			return ykLogin(tx, DefaultPIN)
+		}); err != nil {
+			t.Errorf("failed to login with pin after unblock: %v", err)
+		}
+	})
+}
+
+func TestYubiKeyChangePIN(t *testing.T) {
+	runTest(t, func(t *testing.T, yk *YubiKey) {
+		newPIN := "654321"
+		if err := yk.SetPIN(newPIN, newPIN); err == nil {
+			t.Errorf("successfully changed pin with invalid pin, expected error")
+		}
+		if err := yk.SetPIN(DefaultPIN, newPIN); err != nil {
+			t.Fatalf("changing pin: %v", err)
+		}
+		if err := yk.SetPIN(newPIN, DefaultPIN); err != nil {
+			t.Fatalf("resetting pin: %v", err)
+		}
+	})
+}
+
+func TestYubiKeyChangePUK(t *testing.T) {
+	runTest(t, func(t *testing.T, yk *YubiKey) {
+		newPUK := "87654321"
+		if err := yk.SetPUK(newPUK, newPUK); err == nil {
+			t.Errorf("successfully changed puk with invalid puk, expected error")
+		}
+		if err := yk.SetPUK(DefaultPUK, newPUK); err != nil {
+			t.Fatalf("changing puk: %v", err)
+		}
+		if err := yk.SetPUK(newPUK, DefaultPUK); err != nil {
+			t.Fatalf("resetting puk: %v", err)
+		}
+	})
+}
+
+func TestYubiKeyChangeRetries(t *testing.T) {
+	runTest(t, func(t *testing.T, yk *YubiKey) {
+		if err := yk.SetRetries(DefaultManagementKey, DefaultPIN, 3, 0); err == nil {
+			t.Errorf("successfully set retries to zeros, expected error")
+		}
+		if err := yk.SetRetries(DefaultManagementKey, DefaultPIN, 256, 3); err == nil {
+			t.Errorf("successfully set retries greater than 255, expected error")
+		}
+		if err := yk.SetRetries(DefaultManagementKey, DefaultPIN, 5, 3); err != nil {
+			t.Fatalf("setting pin/puk retries: %v", err)
+		}
+	})
+}
+
+func TestChangeManagementKey(t *testing.T) {
+	runTest(t, func(t *testing.T, yk *YubiKey) {
+		var newKey [24]byte
+		if _, err := io.ReadFull(rand.Reader, newKey[:]); err != nil {
+			t.Fatalf("generating new management key: %v", err)
+		}
+		// Apply odd-parity
+		for i, b := range newKey {
+			if bits.OnesCount8(uint8(b))%2 == 0 {
+				newKey[i] = b ^ 1 // flip least significant bit
+			}
+		}
+		if err := yk.SetManagementKey(newKey[:], newKey[:]); err == nil {
+			t.Errorf("successfully changed management key with invalid key, expected error")
+		}
+		if err := yk.SetManagementKey(DefaultManagementKey, newKey[:]); err != nil {
+			t.Fatalf("changing management key: %v", err)
+		}
+		if err := yk.SetManagementKey(newKey[:], DefaultManagementKey); err != nil {
+			t.Fatalf("resetting management key: %v", err)
+		}
+	})
+}
+
+func TestMetadata(t *testing.T) {
+	runTest(t, func(t *testing.T, yk *YubiKey) {
+		if testing.Short() {
+			t.Skip("skipping test in short mode.")
+		}
+		func() {
+			if err := yk.Reset(); err != nil {
+				t.Fatalf("resetting yubikey: %v", err)
+			}
+		}()
+
+		yk, close := newTestYubiKey(t)
+		defer close()
+
+		if m, err := yk.Metadata(DefaultPIN); err != nil {
+			t.Errorf("getting metadata: %v", err)
+		} else if m.ManagementKey != nil {
+			t.Errorf("expected no management key set")
+		}
+
+		wantKey := []byte{
+			0x09, 0xd9, 0x87, 0x81, 0xfb, 0xdc, 0xc9, 0xb6,
+			0x91, 0xa2, 0x05, 0x80, 0x6e, 0xc0, 0xba, 0x84,
+			0x31, 0xac, 0x0d, 0x9f, 0x59, 0xa5, 0x00, 0xad,
+		}
+		m := &Metadata{
+			ManagementKey: &wantKey,
+		}
+		if err := yk.SetMetadata(DefaultManagementKey, m); err != nil {
+			t.Fatalf("setting metadata: %v", err)
+		}
+		got, err := yk.Metadata(DefaultPIN)
+		if err != nil {
+			t.Fatalf("getting metadata: %v", err)
+		}
+		if got.ManagementKey == nil {
+			t.Errorf("no management key")
+		} else if !bytes.Equal(*got.ManagementKey, wantKey) {
+			t.Errorf("wanted management key=0x%x, got=0x%x", wantKey, got.ManagementKey)
+		}
+	})
 }
 
 func TestMetadataUnmarshal(t *testing.T) {


### PR DESCRIPTION
- Closes #108 (rebase/carry)
- Closes #100

Quoting https://github.com/go-piv/piv-go/pull/108#issuecomment-3105074356:

> I needed this, so I took the liberty of rebasing and updating it (which was a little non-trivial, especially in `piv_test.go`), and I _think_ I've got the same spirit as all the changes here (many of which I had to reimplement green). :bow:
> 
> I've done some testing with it and it resolved a lot of issues I was having (I'm implementing something that can do ECDSA signatures via a YubiKey against this library, and before applying this, any concurrent attempts to sign would fail, and with this change I can happily make seemingly as many concurrent requests as I want and they just stack up, which is exactly how I want it :sparkling_heart:).
> 
> FWIW, I've been testing on a YubiKey 5C, although I will admit I have _not_ run those updated tests (only verified that they compile correctly).

I've now been testing this _very_ actively in a project that does a lot of concurrent accesses to a single YubiKey (via separate processes) to do ECDSA signing and it's been working like a champion for an entire month straight. :smile:

Of course, I'm happy to rebase, amend, close, etc as desired!  The branch has been out there linked from that PR for a bit but I figured maybe it'll be easier to look at/review if I explicitly opened it as a real PR. :heart:

---

- Updates #47
- Closes (maybe?) #172
- Closes #116