### PR TITLE
Fix PIV Card Application AID value to support Nitrokey (Trussed firmware)

### DIFF
--- a/v2/piv/piv.go
+++ b/v2/piv/piv.go
@@ -121,7 +121,6 @@ type YubiKey struct {
 	// YubiKey's version or PIV version? A NEO reports v1.0.4. Figure this out
 	// before exposing an API.
 	version *version
-
 }
 
 // Close releases the connection to the smart card.
@@ -387,7 +386,7 @@ var (
 	// https://github.com/Yubico/yubico-piv-tool/blob/yubico-piv-tool-1.7.0/lib/ykpiv.c#L1117
 
 	aidManagement = [...]byte{0xa0, 0x00, 0x00, 0x05, 0x27, 0x47, 0x11, 0x17}
-	aidPIV        = [...]byte{0xa0, 0x00, 0x00, 0x03, 0x08}
+	aidPIV        = [...]byte{0xa0, 0x00, 0x00, 0x03, 0x08, 0x00, 0x00, 0x10, 0x00, 0x01, 0x00}
 	aidYubiKey    = [...]byte{0xa0, 0x00, 0x00, 0x05, 0x27, 0x20, 0x01, 0x01}
 )
 


### PR DESCRIPTION
By doing this modification I am able to use rsa2048 decryption on a Nitrokey 3A Mini/3A.

Somehow a YubiKey allows to SELECT on the NIST RID prefix of the AID which Nitrokey (Trussed firmware) does not allow.
The NIST PIX suffix is not required by Trussed firmware to work correctly but since it's in the spec and does not impact anything, I kept it.

~~I do not own a YubiKey thus I cannot validate there is no breaking change.~~

```
Device type: YubiKey 5 Nano
Serial number: 42
Firmware version: 5.7.4
Form factor: Nano (USB-A)
Enabled USB interfaces: OTP, FIDO, CCID
```

<details>

<summary>Tests execution</summary>

```
[v2]>> go test -v -timeout 2h ./piv --wipe-yubikey
=== RUN   TestPINPolicyMatchOnceIntegration
    bio_integration_test.go:182: set PIV_BIO_TESTS=1 to run biometric integration tests
--- SKIP: TestPINPolicyMatchOnceIntegration (0.00s)
=== RUN   TestPINPolicyMatchAlwaysTwoVerifications
    bio_integration_test.go:182: set PIV_BIO_TESTS=1 to run biometric integration tests
--- SKIP: TestPINPolicyMatchAlwaysTwoVerifications (0.00s)
=== RUN   TestPINPolicyMatchOnceSingleVerification
    bio_integration_test.go:182: set PIV_BIO_TESTS=1 to run biometric integration tests
--- SKIP: TestPINPolicyMatchOnceSingleVerification (0.00s)
=== RUN   TestYubiKeySignECDSA
--- PASS: TestYubiKeySignECDSA (1.43s)
=== RUN   TestYubiKeyECDSAECDH
=== RUN   TestYubiKeyECDSAECDH/good
=== RUN   TestYubiKeyECDSAECDH/bad
=== RUN   TestYubiKeyECDSAECDH/bad/size
--- PASS: TestYubiKeyECDSAECDH (0.51s)
    --- PASS: TestYubiKeyECDSAECDH/good (0.07s)
    --- PASS: TestYubiKeyECDSAECDH/bad (0.00s)
        --- PASS: TestYubiKeyECDSAECDH/bad/size (0.00s)
=== RUN   TestYubiKeyECDSASharedKey
=== RUN   TestYubiKeyECDSASharedKey/good
=== RUN   TestYubiKeyECDSASharedKey/bad
=== RUN   TestYubiKeyECDSASharedKey/bad/size
--- PASS: TestYubiKeyECDSASharedKey (0.51s)
    --- PASS: TestYubiKeyECDSASharedKey/good (0.07s)
    --- PASS: TestYubiKeyECDSASharedKey/bad (0.00s)
        --- PASS: TestYubiKeyECDSASharedKey/bad/size (0.00s)
=== RUN   TestYubiKeyX25519ECDH
=== RUN   TestYubiKeyX25519ECDH/good
=== RUN   TestYubiKeyX25519ECDH/bad
=== RUN   TestYubiKeyX25519ECDH/bad/curve
--- PASS: TestYubiKeyX25519ECDH (0.24s)
    --- PASS: TestYubiKeyX25519ECDH/good (0.08s)
    --- PASS: TestYubiKeyX25519ECDH/bad (0.00s)
        --- PASS: TestYubiKeyX25519ECDH/bad/curve (0.00s)
=== RUN   TestYubiKeySignEd25519
=== RUN   TestYubiKeySignEd25519/good
=== RUN   TestYubiKeySignEd25519/unsupported_ed25519ph
=== RUN   TestYubiKeySignEd25519/unsupported_ed25519ctx
--- PASS: TestYubiKeySignEd25519 (1.43s)
    --- PASS: TestYubiKeySignEd25519/good (0.08s)
    --- PASS: TestYubiKeySignEd25519/unsupported_ed25519ph (0.00s)
    --- PASS: TestYubiKeySignEd25519/unsupported_ed25519ctx (0.00s)
=== RUN   TestPINPrompt
=== RUN   TestPINPrompt/Never
=== RUN   TestPINPrompt/Once
=== RUN   TestPINPrompt/Always
--- PASS: TestPINPrompt (1.79s)
    --- PASS: TestPINPrompt/Never (0.58s)
    --- PASS: TestPINPrompt/Once (0.60s)
    --- PASS: TestPINPrompt/Always (0.60s)
=== RUN   TestSlots
=== RUN   TestSlots/Authentication
=== RUN   TestSlots/CardAuthentication
=== RUN   TestSlots/KeyManagement
=== RUN   TestSlots/Signature
--- PASS: TestSlots (3.76s)
    --- PASS: TestSlots/Authentication (0.71s)
    --- PASS: TestSlots/CardAuthentication (0.70s)
    --- PASS: TestSlots/KeyManagement (0.70s)
    --- PASS: TestSlots/Signature (0.70s)
=== RUN   TestYubiKeySignRSA
=== RUN   TestYubiKeySignRSA/rsa1024
=== RUN   TestYubiKeySignRSA/rsa2048
=== RUN   TestYubiKeySignRSA/rsa3072
=== RUN   TestYubiKeySignRSA/rsa4096
--- PASS: TestYubiKeySignRSA (57.48s)
    --- PASS: TestYubiKeySignRSA/rsa1024 (0.99s)
    --- PASS: TestYubiKeySignRSA/rsa2048 (7.85s)
    --- PASS: TestYubiKeySignRSA/rsa3072 (22.45s)
    --- PASS: TestYubiKeySignRSA/rsa4096 (26.19s)
=== RUN   TestYubiKeySignRSAPSS
=== RUN   TestYubiKeySignRSAPSS/rsa1024
=== RUN   TestYubiKeySignRSAPSS/rsa2048
=== RUN   TestYubiKeySignRSAPSS/rsa3072
=== RUN   TestYubiKeySignRSAPSS/rsa4096
--- PASS: TestYubiKeySignRSAPSS (169.19s)
    --- PASS: TestYubiKeySignRSAPSS/rsa1024 (0.85s)
    --- PASS: TestYubiKeySignRSAPSS/rsa2048 (7.67s)
    --- PASS: TestYubiKeySignRSAPSS/rsa3072 (9.95s)
    --- PASS: TestYubiKeySignRSAPSS/rsa4096 (150.72s)
=== RUN   TestTLS13
--- PASS: TestTLS13 (1.04s)
=== RUN   TestYubiKeyDecryptRSA
=== RUN   TestYubiKeyDecryptRSA/rsa1024
=== RUN   TestYubiKeyDecryptRSA/rsa2048
=== RUN   TestYubiKeyDecryptRSA/rsa3072
=== RUN   TestYubiKeyDecryptRSA/rsa4096
--- PASS: TestYubiKeyDecryptRSA (117.92s)
    --- PASS: TestYubiKeyDecryptRSA/rsa1024 (1.32s)
    --- PASS: TestYubiKeyDecryptRSA/rsa2048 (3.02s)
    --- PASS: TestYubiKeyDecryptRSA/rsa3072 (33.30s)
    --- PASS: TestYubiKeyDecryptRSA/rsa4096 (80.28s)
=== RUN   TestYubiKeyAttestation
--- PASS: TestYubiKeyAttestation (0.61s)
=== RUN   TestYubiKeyStoreCertificate
--- PASS: TestYubiKeyStoreCertificate (0.51s)
=== RUN   TestYubiKeyGenerateKey
=== RUN   TestYubiKeyGenerateKey/ec_256
=== RUN   TestYubiKeyGenerateKey/ec_384
=== RUN   TestYubiKeyGenerateKey/rsa_1024
=== RUN   TestYubiKeyGenerateKey/rsa_2048
=== RUN   TestYubiKeyGenerateKey/rsa_2048#01
=== RUN   TestYubiKeyGenerateKey/rsa_3072
=== RUN   TestYubiKeyGenerateKey/rsa_4096
=== RUN   TestYubiKeyGenerateKey/ed25519
--- PASS: TestYubiKeyGenerateKey (84.47s)
    --- PASS: TestYubiKeyGenerateKey/ec_256 (0.43s)
    --- PASS: TestYubiKeyGenerateKey/ec_384 (0.75s)
    --- PASS: TestYubiKeyGenerateKey/rsa_1024 (0.74s)
    --- PASS: TestYubiKeyGenerateKey/rsa_2048 (7.28s)
    --- PASS: TestYubiKeyGenerateKey/rsa_2048#01 (8.70s)
    --- PASS: TestYubiKeyGenerateKey/rsa_3072 (48.84s)
    --- PASS: TestYubiKeyGenerateKey/rsa_4096 (17.35s)
    --- PASS: TestYubiKeyGenerateKey/ed25519 (0.38s)
=== RUN   TestYubiKeyPrivateKey
--- PASS: TestYubiKeyPrivateKey (0.51s)
=== RUN   TestYubiKeyPrivateKeyPINError
--- PASS: TestYubiKeyPrivateKeyPINError (0.43s)
=== RUN   TestRetiredKeyManagementSlot
=== RUN   TestRetiredKeyManagementSlot/Non-existent_slot,_before_range
=== RUN   TestRetiredKeyManagementSlot/Non-existent_slot,_after_range
=== RUN   TestRetiredKeyManagementSlot/First_retired_slot_key
=== RUN   TestRetiredKeyManagementSlot/Last_retired_slot_key
--- PASS: TestRetiredKeyManagementSlot (0.00s)
    --- PASS: TestRetiredKeyManagementSlot/Non-existent_slot,_before_range (0.00s)
    --- PASS: TestRetiredKeyManagementSlot/Non-existent_slot,_after_range (0.00s)
    --- PASS: TestRetiredKeyManagementSlot/First_retired_slot_key (0.00s)
    --- PASS: TestRetiredKeyManagementSlot/Last_retired_slot_key (0.00s)
=== RUN   TestSetRSAPrivateKey
=== RUN   TestSetRSAPrivateKey/rsa_1024
=== RUN   TestSetRSAPrivateKey/rsa_2048
=== RUN   TestSetRSAPrivateKey/rsa_512
    key_test.go:1126: generating private key: crypto/rsa: 512-bit keys are insecure (see https://go.dev/pkg/crypto/rsa#hdr-Minimum_key_size)
--- FAIL: TestSetRSAPrivateKey (0.85s)
    --- PASS: TestSetRSAPrivateKey/rsa_1024 (0.25s)
    --- PASS: TestSetRSAPrivateKey/rsa_2048 (0.59s)
    --- FAIL: TestSetRSAPrivateKey/rsa_512 (0.02s)
=== RUN   TestSetECDSAPrivateKey
=== RUN   TestSetECDSAPrivateKey/ecdsa_P256
=== RUN   TestSetECDSAPrivateKey/ecdsa_P384
=== RUN   TestSetECDSAPrivateKey/ecdsa_P224
=== RUN   TestSetECDSAPrivateKey/ecdsa_P521
--- PASS: TestSetECDSAPrivateKey (1.44s)
    --- PASS: TestSetECDSAPrivateKey/ecdsa_P256 (0.51s)
    --- PASS: TestSetECDSAPrivateKey/ecdsa_P384 (0.90s)
    --- PASS: TestSetECDSAPrivateKey/ecdsa_P224 (0.02s)
    --- PASS: TestSetECDSAPrivateKey/ecdsa_P521 (0.02s)
=== RUN   TestParseSlot
=== RUN   TestParseSlot/Missing_Yubico_PIV_Prefix
=== RUN   TestParseSlot/Invalid_Slot_Name
=== RUN   TestParseSlot/Valid_--_SlotAuthentication
=== RUN   TestParseSlot/Valid_--_Retired_Management_Key
--- PASS: TestParseSlot (0.00s)
    --- PASS: TestParseSlot/Missing_Yubico_PIV_Prefix (0.00s)
    --- PASS: TestParseSlot/Invalid_Slot_Name (0.00s)
    --- PASS: TestParseSlot/Valid_--_SlotAuthentication (0.00s)
    --- PASS: TestParseSlot/Valid_--_Retired_Management_Key (0.00s)
=== RUN   TestVerify
=== RUN   TestVerify/ValidChain
=== RUN   TestVerify/ValidChain2018
=== RUN   TestVerify/InvalidChain
=== RUN   TestVerify/InvalidChain2
--- PASS: TestVerify (0.00s)
    --- PASS: TestVerify/ValidChain (0.00s)
    --- PASS: TestVerify/ValidChain2018 (0.00s)
    --- PASS: TestVerify/InvalidChain (0.00s)
    --- PASS: TestVerify/InvalidChain2 (0.00s)
=== RUN   TestKeyInfo
=== RUN   TestKeyInfo/Generated_ec_256
=== RUN   TestKeyInfo/Generated_ec_384
=== RUN   TestKeyInfo/Generated_rsa_1024
=== RUN   TestKeyInfo/Generated_rsa_2048
=== RUN   TestKeyInfo/Generated_rsa_3072
=== RUN   TestKeyInfo/Generated_rsa_4096
=== RUN   TestKeyInfo/Generated_ed25517
=== RUN   TestKeyInfo/Generated_x25517
=== RUN   TestKeyInfo/Imported_ec_256
=== RUN   TestKeyInfo/Imported_ec_384
=== RUN   TestKeyInfo/Imported_rsa_1024
=== RUN   TestKeyInfo/Imported_rsa_2048
=== RUN   TestKeyInfo/Imported_rsa_3072
=== RUN   TestKeyInfo/Imported_rsa_4096
=== RUN   TestKeyInfo/Imported_ed25519
=== RUN   TestKeyInfo/Imported_x25519
=== RUN   TestKeyInfo/PINPolicyOnce
=== RUN   TestKeyInfo/PINPolicyAlways
=== RUN   TestKeyInfo/TouchPolicyAlways
=== RUN   TestKeyInfo/TouchPolicyCached
=== RUN   TestKeyInfo/SlotSignature
=== RUN   TestKeyInfo/SlotCardAuthentication
=== RUN   TestKeyInfo/SlotKeyManagement
--- PASS: TestKeyInfo (80.71s)
    --- PASS: TestKeyInfo/Generated_ec_256 (0.43s)
    --- PASS: TestKeyInfo/Generated_ec_384 (0.75s)
    --- PASS: TestKeyInfo/Generated_rsa_1024 (0.66s)
    --- PASS: TestKeyInfo/Generated_rsa_2048 (15.82s)
    --- PASS: TestKeyInfo/Generated_rsa_3072 (10.53s)
    --- PASS: TestKeyInfo/Generated_rsa_4096 (41.80s)
    --- PASS: TestKeyInfo/Generated_ed25517 (0.38s)
    --- PASS: TestKeyInfo/Generated_x25517 (0.39s)
    --- PASS: TestKeyInfo/Imported_ec_256 (0.44s)
    --- PASS: TestKeyInfo/Imported_ec_384 (0.76s)
    --- PASS: TestKeyInfo/Imported_rsa_1024 (0.18s)
    --- PASS: TestKeyInfo/Imported_rsa_2048 (0.40s)
    --- PASS: TestKeyInfo/Imported_rsa_3072 (1.07s)
    --- PASS: TestKeyInfo/Imported_rsa_4096 (1.70s)
    --- PASS: TestKeyInfo/Imported_ed25519 (0.38s)
    --- PASS: TestKeyInfo/Imported_x25519 (0.16s)
    --- PASS: TestKeyInfo/PINPolicyOnce (0.44s)
    --- PASS: TestKeyInfo/PINPolicyAlways (0.44s)
    --- PASS: TestKeyInfo/TouchPolicyAlways (0.43s)
    --- PASS: TestKeyInfo/TouchPolicyCached (0.44s)
    --- PASS: TestKeyInfo/SlotSignature (0.44s)
    --- PASS: TestKeyInfo/SlotCardAuthentication (0.44s)
    --- PASS: TestKeyInfo/SlotKeyManagement (0.44s)
=== RUN   TestPINPolicy
--- PASS: TestPINPolicy (1.39s)
=== RUN   TestFindTLVTag
=== RUN   TestFindTLVTag/simple_tag
=== RUN   TestFindTLVTag/tag_not_found
=== RUN   TestFindTLVTag/multi-byte_tag_(2_bytes)
=== RUN   TestFindTLVTag/multi-byte_tag_(3_bytes)
=== RUN   TestFindTLVTag/multi-byte_tag_(4_bytes)
=== RUN   TestFindTLVTag/multi-byte_tag_too_long
=== RUN   TestFindTLVTag/long_form_length
=== RUN   TestFindTLVTag/malformed_TLV_(EOF_in_tag)
=== RUN   TestFindTLVTag/malformed_TLV_(EOF_in_length)
=== RUN   TestFindTLVTag/malformed_TLV_(EOF_in_value)
=== RUN   TestFindTLVTag/malformed_TLV_(indefinite_length_unsupported)
--- PASS: TestFindTLVTag (0.00s)
    --- PASS: TestFindTLVTag/simple_tag (0.00s)
    --- PASS: TestFindTLVTag/tag_not_found (0.00s)
    --- PASS: TestFindTLVTag/multi-byte_tag_(2_bytes) (0.00s)
    --- PASS: TestFindTLVTag/multi-byte_tag_(3_bytes) (0.00s)
    --- PASS: TestFindTLVTag/multi-byte_tag_(4_bytes) (0.00s)
    --- PASS: TestFindTLVTag/multi-byte_tag_too_long (0.00s)
    --- PASS: TestFindTLVTag/long_form_length (0.00s)
    --- PASS: TestFindTLVTag/malformed_TLV_(EOF_in_tag) (0.00s)
    --- PASS: TestFindTLVTag/malformed_TLV_(EOF_in_length) (0.00s)
    --- PASS: TestFindTLVTag/malformed_TLV_(EOF_in_value) (0.00s)
    --- PASS: TestFindTLVTag/malformed_TLV_(indefinite_length_unsupported) (0.00s)
=== RUN   TestContextClose
--- PASS: TestContextClose (0.00s)
=== RUN   TestContextListReaders
--- PASS: TestContextListReaders (0.00s)
=== RUN   TestHandle
--- PASS: TestHandle (0.01s)
=== RUN   TestTransaction
--- PASS: TestTransaction (0.01s)
=== RUN   TestErrors
--- PASS: TestErrors (0.00s)
=== RUN   TestGetVersion
--- PASS: TestGetVersion (0.01s)
=== RUN   TestCards
--- PASS: TestCards (0.00s)
=== RUN   TestNewYubiKey
--- PASS: TestNewYubiKey (0.02s)
=== RUN   TestMultipleConnections
--- PASS: TestMultipleConnections (0.02s)
=== RUN   TestYubiKeySerial
--- PASS: TestYubiKeySerial (0.02s)
=== RUN   TestYubiKeyLoginNeeded
--- PASS: TestYubiKeyLoginNeeded (0.02s)
=== RUN   TestYubiKeyPINRetries
--- PASS: TestYubiKeyPINRetries (1.01s)
=== RUN   TestYubiKeyReset
--- PASS: TestYubiKeyReset (0.96s)
=== RUN   TestYubiKeyLogin
--- PASS: TestYubiKeyLogin (0.02s)
=== RUN   TestYubiKeyAuthenticate
--- PASS: TestYubiKeyAuthenticate (0.02s)
=== RUN   TestYubiKeySetManagementKey
--- PASS: TestYubiKeySetManagementKey (0.05s)
=== RUN   TestYubiKeyUnblockPIN
--- PASS: TestYubiKeyUnblockPIN (0.07s)
=== RUN   TestYubiKeyChangePIN
--- PASS: TestYubiKeyChangePIN (0.06s)
=== RUN   TestYubiKeyChangePUK
--- PASS: TestYubiKeyChangePUK (0.07s)
=== RUN   TestYubiKeyChangeRetries
--- PASS: TestYubiKeyChangeRetries (0.04s)
=== RUN   TestChangeManagementKey
--- PASS: TestChangeManagementKey (0.04s)
=== RUN   TestMetadata
--- PASS: TestMetadata (1.02s)
=== RUN   TestMetadataUnmarshal
--- PASS: TestMetadataUnmarshal (0.00s)
=== RUN   TestMetadataMarshal
--- PASS: TestMetadataMarshal (0.00s)
=== RUN   TestMetadataUpdate
--- PASS: TestMetadataUpdate (0.00s)
=== RUN   TestMetadataAdditoinalFields
--- PASS: TestMetadataAdditoinalFields (0.00s)
```

</details>

https://csrc.nist.gov/pubs/sp/800/73/4/upd1/final
https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-73-4.pdf

<img width="732" height="364" alt="image" src="https://github.com/user-attachments/assets/3f665894-fd4d-452f-ad06-1a152882cebe" />
