### PR TITLE
Release the card when Open fails after connecting

### DIFF
--- a/v2/piv/piv.go
+++ b/v2/piv/piv.go
@@ -167,14 +167,21 @@ func (c *client) Open(card string) (*YubiKey, error) {
 	h, err := ctx.Connect(card)
 	if err != nil {
 		ctx.Close()
-		return nil, fmt.Errorf("connecting to smart card: %w", err)
+		return nil, fmt.Errorf("connecting to smart card %q: %w", card, err)
 	}
 	tx, err := h.Begin()
 	if err != nil {
+		// Open returns no handle on failure, so the caller can't release the
+		// card. Without these closes the exclusive connection is held until
+		// the process exits and later opens fail with a sharing violation.
+		h.Close()
+		ctx.Close()
 		return nil, fmt.Errorf("beginning smart card transaction: %w", err)
 	}
 	if err := ykSelectApplication(tx, aidPIV[:]); err != nil {
 		tx.Close()
+		h.Close()
+		ctx.Close()
 		return nil, fmt.Errorf("selecting piv applet: %w", err)
 	}
 

--- a/v2/piv/piv_test.go
+++ b/v2/piv/piv_test.go
@@ -164,8 +164,13 @@ func TestOpenErrorReleasesCard(t *testing.T) {
 		// Selecting an applet that isn't installed fails Open after it has
 		// already connected to the card, the same path taken by a reader
 		// holding a card that doesn't implement PIV.
+		//
+		// Change a byte in place rather than assigning a new AID, so this
+		// doesn't depend on the length of aidPIV, which #189 would grow. The
+		// byte is inside the PIV AID itself, so the select still misses on a
+		// card that matches a truncated AID.
 		aid := aidPIV
-		aidPIV = [...]byte{0xa0, 0x00, 0x00, 0x03, 0xff}
+		aidPIV[4] = 0xff
 		yk, err := Open(card)
 		aidPIV = aid
 		if err == nil {

--- a/v2/piv/piv_test.go
+++ b/v2/piv/piv_test.go
@@ -147,6 +147,53 @@ func TestMultipleConnections(t *testing.T) {
 	t.Skip("no yubikeys detected, skipping")
 }
 
+func TestOpenErrorReleasesCard(t *testing.T) {
+	if !canModifyYubiKey {
+		t.Skip("not running test that accesses yubikey, provide --wipe-yubikey flag")
+	}
+
+	cards, err := Cards()
+	if err != nil {
+		t.Fatalf("listing cards: %v", err)
+	}
+	for _, card := range cards {
+		if !strings.Contains(strings.ToLower(card), "yubikey") {
+			continue
+		}
+
+		// Selecting an applet that isn't installed fails Open after it has
+		// already connected to the card, the same path taken by a reader
+		// holding a card that doesn't implement PIV.
+		aid := aidPIV
+		aidPIV = [...]byte{0xa0, 0x00, 0x00, 0x03, 0xff}
+		yk, err := Open(card)
+		aidPIV = aid
+		if err == nil {
+			yk.Close()
+			t.Fatalf("expected open to fail selecting piv applet")
+		}
+		// A card held by another process fails Open at the connect instead,
+		// which never reaches the path under test and would make the open
+		// below fail for an unrelated reason.
+		if !errors.Is(err, ErrNotFound) {
+			t.Fatalf("expected open to fail selecting piv applet, got: %v", err)
+		}
+
+		// Open holds the card exclusively and returns no handle on failure, so
+		// if it didn't release the card itself this reports a sharing
+		// violation.
+		yk, err = Open(card)
+		if err != nil {
+			t.Fatalf("opening yubikey after a failed open: %v", err)
+		}
+		if err := yk.Close(); err != nil {
+			t.Errorf("closing yubikey: %v", err)
+		}
+		return
+	}
+	t.Skip("no yubikeys detected, skipping")
+}
+
 func TestYubiKeySerial(t *testing.T) {
 	yk, close := newTestYubiKey(t)
 	defer close()


### PR DESCRIPTION
## Summary
`client.Open` connects with `SCARD_SHARE_EXCLUSIVE` and then, on both of the failure paths that follow a successful connect, returns `(nil, err)` without disconnecting. The card stays exclusively locked for the life of the process, and because `Open` returns a nil `*YubiKey`, the caller is handed nothing it could release it with. There are no finalizers (`grep -r SetFinalizer v2/` is empty), so nothing reclaims the handle.

`ykSelectApplication` fails for any card without the PIV applet, so the leak fires on the ordinary "walk the readers and find the YubiKey" pattern — including the one in this repo's README. Every non-PIV card such a caller probes gets locked until the process exits, and a later `Open` of that card returns `SCARD_E_SHARING_VIOLATION` ("the smart card cannot be accessed because of other connections outstanding") even though the caller closed everything it was ever given. Because `Open` gives the caller nothing to close, no caller can work around this.

The fix:
Close the handle and then the context on both paths, matching the teardown order in `YubiKey.Close`. The success path is untouched and no PC/SC parameter is changed. The only symbols newly referenced are `scHandle.Close()` and `scContext.Close()`, which already exist with identical signatures in both `pcsc_windows.go` and `pcsc_unix.go` — there is no platform-specific code in the change.

## Error message change
The connect error now names the reader: `connecting to smart card %q: %w`.

This is separable, but bundled here for convenience — happy to split it into its own commit if you prefer. It changes rendered text only; the `%w` wrap is unchanged, so `errors.Is`/`errors.As` behave exactly as before.

## Testing

`TestOpenErrorReleasesCard` drives the `ykSelectApplication` failure path — the path every non-PIV card takes — by pointing the applet select at an AID the card doesn't have, then reopens the card to prove it was released. It is gated on `--wipe-yubikey` like the other tests that touch hardware, and it writes nothing to the card (one `SELECT` APDU, rejected with `6A82`; PIN retries unchanged).

Tested against a real YubiKey on both resource managers — winscard on Windows 11, and pcsc-lite 1.9.9 on Raspbian bookworm (linux/arm). On both, the test fails before the change (the second `Open` reports `SCARD_E_SHARING_VIOLATION`) and passes after. `go test -C v2 ./...` — the Linux CI job — passes with the change applied.

CI won't run the new test itself: the Linux job doesn't pass `--wipe-yubikey` and the Windows job is build-only. The leak is resource teardown with no pure-logic seam to table-test, so a hardware-gated test is the best here, as it is for every other connect-path test in the package. Happy to drop it if you'd rather not carry it.

| | winscard (Windows 11, WUDF inbox driver) | pcsc-lite 1.9.9 (Raspbian bookworm, linux/arm) |
|---|---|---|
| leak test on `v2` HEAD | **FAIL** — sharing violation | **FAIL** — leak reproduces |
| leak test, patched | **PASS** | **PASS** |

Not verified: macOS, and 64-bit Linux — the Linux measurements above are 32-bit ARM.

The Google CLA is signed.

Reviewed and refined with AI assistance; all hardware measurements run and verified by me.