### PR TITLE
Decode pcsc return codes on 32 bit unix

### DIFF
--- a/v2/piv/pcsc.go
+++ b/v2/piv/pcsc.go
@@ -24,6 +24,22 @@ type scErr struct {
 	rc int64
 }
 
+// newSCErr builds an scErr from a PC/SC return code.
+//
+// Where the C type holding the code is a 32 bit signed integer (C.int on
+// darwin always, C.long on the other cgo unix platforms when the platform
+// is 32 bit), the leading bit of a code such as 0x8010000b is a sign bit,
+// so the code arrives negative and matches nothing in pcscErrMsgs. newSCErr
+// corrects it back to the positive value pcscErrMsgs is keyed on.
+//
+// https://github.com/go-piv/piv-go/issues/53
+func newSCErr(rc int64) *scErr {
+	if rc < 0 {
+		rc += 1 << 32
+	}
+	return &scErr{rc}
+}
+
 func (e *scErr) Error() string {
 	if msg, ok := pcscErrMsgs[e.rc]; ok {
 		return msg

--- a/v2/piv/pcsc_darwin.go
+++ b/v2/piv/pcsc_darwin.go
@@ -20,15 +20,7 @@ func scCheck(rc C.int) error {
 	if rc == rcSuccess {
 		return nil
 	}
-	i := int64(rc)
-	if i < 0 {
-		// On MacOS, int isn't big enough to handle the return codes so the
-		// leading bit becomes a two's complement bit. If the return code is
-		// negative, correct this.
-		// https://github.com/go-piv/piv-go/issues/53
-		i += (1 << 32)
-	}
-	return &scErr{i}
+	return newSCErr(int64(rc))
 }
 
 func isRCNoReaders(rc C.int) bool {

--- a/v2/piv/pcsc_freebsd.go
+++ b/v2/piv/pcsc_freebsd.go
@@ -22,7 +22,7 @@ func scCheck(rc C.long) error {
 	if rc == rcSuccess {
 		return nil
 	}
-	return &scErr{int64(rc)}
+	return newSCErr(int64(rc))
 }
 
 func isRCNoReaders(rc C.long) bool {

--- a/v2/piv/pcsc_linux.go
+++ b/v2/piv/pcsc_linux.go
@@ -22,7 +22,7 @@ func scCheck(rc C.long) error {
 	if rc == rcSuccess {
 		return nil
 	}
-	return &scErr{int64(rc)}
+	return newSCErr(int64(rc))
 }
 
 func isRCNoReaders(rc C.long) bool {

--- a/v2/piv/pcsc_openbsd.go
+++ b/v2/piv/pcsc_openbsd.go
@@ -22,7 +22,7 @@ func scCheck(rc C.long) error {
 	if rc == rcSuccess {
 		return nil
 	}
-	return &scErr{int64(rc)}
+	return newSCErr(int64(rc))
 }
 
 func isRCNoReaders(rc C.long) bool {

--- a/v2/piv/pcsc_test.go
+++ b/v2/piv/pcsc_test.go
@@ -140,3 +140,36 @@ func TestErrors(t *testing.T) {
 		}
 	}
 }
+
+func TestSCError(t *testing.T) {
+	// as32 returns rc as it arrives through a 32 bit signed C type (long on
+	// 32 bit unix, int on darwin): the leading bit is read as a sign bit.
+	as32 := func(rc uint32) int64 { return int64(int32(rc)) }
+
+	tests := []struct {
+		rc   int64
+		desc string
+	}{
+		{0x8010000b, "the smart card cannot be accessed because of other connections outstanding"},
+		{as32(0x8010000b), "the smart card cannot be accessed because of other connections outstanding"},
+		{0x8010000c, "the operation requires a Smart Card, but no Smart Card is currently in the device"},
+		{as32(0x8010000c), "the operation requires a Smart Card, but no Smart Card is currently in the device"},
+		{0x80100069, "the smart card has been removed, so further communication is not possible"},
+		{as32(0x80100069), "the smart card has been removed, so further communication is not possible"},
+		{0x00000000, "no error was encountered"},
+		{0x0000ffff, "unknown pcsc return code 0x0000ffff"},
+		{as32(0x80100022), "unknown pcsc return code 0x80100022"},
+	}
+
+	for _, tc := range tests {
+		e := newSCErr(tc.rc)
+		if got := e.Error(); got != tc.desc {
+			t.Errorf("return code 0x%08x: got %q, want %q", tc.rc, got, tc.desc)
+		}
+		// Callers compare against rc directly, so the field itself must hold
+		// the positive code, not just render as one.
+		if e.rc < 0 {
+			t.Errorf("return code 0x%08x: rc field holds 0x%x, want the positive code", tc.rc, e.rc)
+		}
+	}
+}


### PR DESCRIPTION
This code generalizes the fix for outputting error codes on a 32 bit systems. This overflow has already been fixed twice (PR 81 and PR 107). Rather than add a conversions for the remaining unix platforms, moved the correction into newSCErr in pcsc.go, and have all four cgo unix platforms build their scErr through it. Windows is unaffected and untouched: it converts from an unsigned uintptr, so the codes are never negative. On 64 bit unix the correction is a no-op, since a 64 bit long already holds the codes as positive values, which is why CI has never seen this: both jobs are amd64.

    47b85fc  fix: overflows _Ctype_long on linux x32     (PR #81)
    -       return rc == 0x8010002E
    +       return C.ulong(rc) == 0x8010002E

    1902689  piv/pcsc_freebsd.go: fix build on 32 bit FreeBSD  (PR #107)
    -       return rc == 0x8010002E
    +       return uint32(rc) == 0x8010002E

pcscErrMsgs is keyed on the return codes as PC/SC defines them, all of which have their leading bit set, such as 0x8010000b for SCARD_E_SHARING_VIOLATION. On linux, freebsd and openbsd scCheck stores the code as int64(rc) where rc is a C.long. That long is 32 bits wide on 32 bit platforms, so the leading bit is a sign bit, the conversion sign extends, and the code arrives as -0x7feffff5. It matches nothing in pcscErrMsgs, so every PC/SC error renders through the fallback in scErr.Error as "unknown pcsc return code 0x-7feffff5", which is both wrong and not a hex number. Since every SCARD_E_ and SCARD_W_ code has its leading bit set, no PC/SC error message decodes at all on 32 bit unix.

pcsc.go has no build tag and no cgo, so unlike the platform files it is reachable from a plain test. TestSCError checks the native and the sign extended form of each of the three codes the connect path can return and of an unmapped code, and that the corrected code is stored in scErr itself rather than fixed up at render time, since callers compare against it directly. It needs no smart card and runs in the existing linux job, so it is the first coverage of this bug class that CI can execute.