### PR TITLE
piv: add ErrSecurityStatusNotSatisfied for 0x6982

### DIFF
--- a/v2/piv/pcsc.go
+++ b/v2/piv/pcsc.go
@@ -50,10 +50,15 @@ func (v AuthErr) Error() string {
 // ErrNotFound is returned when the requested object on the smart card is not found.
 var ErrNotFound = errors.New("data object or application not found")
 
+// ErrSecurityStatusNotSatisfied is returned when the card reports that a
+// security condition, such as PIN verification or a required touch, was not
+// satisfied.
+var ErrSecurityStatusNotSatisfied = errors.New("security status not satisfied")
+
 // apduErr is an error interacting with the PIV application on the smart card.
-// This error may wrap more accessible errors, like ErrNotFound or an instance
-// of AuthErr, so callers are encouraged to use errors.Is and errors.As for
-// these common cases.
+// This error may wrap more accessible errors, like ErrNotFound,
+// ErrSecurityStatusNotSatisfied, or an instance of AuthErr, so callers are
+// encouraged to use errors.Is and errors.As for these common cases.
 type apduErr struct {
 	sw1 byte
 	sw2 byte
@@ -112,6 +117,8 @@ func (a *apduErr) Unwrap() error {
 		return ErrNotFound
 	case st == 0x6a88:
 		return ErrNotFound
+	case st == 0x6982:
+		return ErrSecurityStatusNotSatisfied
 	case st == 0x6300:
 		return AuthErr{0}
 	case st == 0x6983:

--- a/v2/piv/pcsc_test.go
+++ b/v2/piv/pcsc_test.go
@@ -140,3 +140,16 @@ func TestErrors(t *testing.T) {
 		}
 	}
 }
+
+func TestErrSecurityStatusNotSatisfied(t *testing.T) {
+	err := &apduErr{0x69, 0x82}
+	if !errors.Is(err, ErrSecurityStatusNotSatisfied) {
+		t.Errorf("0x6982 should unwrap to ErrSecurityStatusNotSatisfied")
+	}
+	if errors.Is(&apduErr{0x6a, 0x82}, ErrSecurityStatusNotSatisfied) {
+		t.Errorf("0x6a82 should not be ErrSecurityStatusNotSatisfied")
+	}
+	if got, want := err.Error(), "smart card error 6982: security status not satisfied"; got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
apduErr.Unwrap already maps 0x6a82/0x6a88 to ErrNotFound and the 0x63xx family to AuthErr, but not 0x6982, so callers could only recognize it by formatting Status() by hand. Add an exported ErrSecurityStatusNotSatisfied sentinel and unwrap 0x6982 to it so callers can use errors.Is.

0x6982 ("security status not satisfied") is returned when a required security condition is not met -- often a slot whose touch policy is waiting for a physical touch, but also an unsatisfied PIN condition.

Error() is unchanged: its switch already renders "security status not satisfied" for 0x6982, which overrides the unwrapped sentinel's identical message.